### PR TITLE
Add live GitHub profile, projects, and social links to home page

### DIFF
--- a/src/app/components/profile.tsx
+++ b/src/app/components/profile.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { getGithubProfile } from '@/app/lib/github'
 
-const LINKEDIN_URL = 'https://www.linkedin.com/in/adarshm/'
+const LINKEDIN_URL = 'https://www.linkedin.com/in/adarshm07/'
 
 function GithubIcon() {
   return (

--- a/src/app/components/profile.tsx
+++ b/src/app/components/profile.tsx
@@ -1,0 +1,111 @@
+import Image from 'next/image'
+import { getGithubProfile } from '@/app/lib/github'
+
+const LINKEDIN_URL = 'https://www.linkedin.com/in/adarshm/'
+
+function GithubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current" aria-hidden>
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  )
+}
+
+function TwitterIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current" aria-hidden>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  )
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current" aria-hidden>
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  )
+}
+
+export async function Profile() {
+  const profile = await getGithubProfile()
+
+  const name = profile?.name ?? 'Adarsh M'
+  const bio = profile?.bio ?? '⚡ Learning JS'
+  const location = profile?.location ?? 'Kerala, India'
+  const avatarUrl = profile?.avatar_url ?? null
+  const publicRepos = profile?.public_repos ?? 61
+  const followers = profile?.followers ?? 8
+  const twitterUsername = profile?.twitter_username ?? 'adarshm07'
+  const githubUrl = profile?.html_url ?? 'https://github.com/adarshm07'
+
+  return (
+    <div className="flex flex-col sm:flex-row items-start gap-5">
+      {avatarUrl && (
+        <Image
+          src={avatarUrl}
+          alt={name}
+          width={80}
+          height={80}
+          className="rounded-full ring-2 ring-neutral-100 dark:ring-neutral-800 shrink-0"
+          priority
+        />
+      )}
+
+      <div className="flex-1 min-w-0">
+        <h1 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+          {name}
+        </h1>
+        <p className="mt-0.5 text-sm text-neutral-500 dark:text-neutral-400">
+          {bio}
+        </p>
+        <p className="mt-0.5 text-sm text-neutral-400 dark:text-neutral-500">
+          {location}
+        </p>
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2">
+          <div className="flex items-center gap-4 text-xs text-neutral-400 dark:text-neutral-500">
+            <span>
+              <strong className="text-neutral-700 dark:text-neutral-300">{publicRepos}</strong> repos
+            </span>
+            <span>
+              <strong className="text-neutral-700 dark:text-neutral-300">{followers}</strong> followers
+            </span>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <a
+              href={githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+              className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+            >
+              <GithubIcon />
+            </a>
+            {twitterUsername && (
+              <a
+                href={`https://x.com/${twitterUsername}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="X / Twitter"
+                className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+              >
+                <TwitterIcon />
+              </a>
+            )}
+            <a
+              href={LINKEDIN_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn"
+              className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+            >
+              <LinkedInIcon />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/projects.tsx
+++ b/src/app/components/projects.tsx
@@ -1,0 +1,91 @@
+import { getGithubRepos } from '@/app/lib/github'
+
+const languageColors: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572A5',
+  CSS: '#563d7c',
+  HTML: '#e34c26',
+  PHP: '#4F5D95',
+  Shell: '#89e051',
+  Rust: '#dea584',
+  Go: '#00ADD8',
+  Ruby: '#701516',
+}
+
+function StarIcon() {
+  return (
+    <svg viewBox="0 0 16 16" className="h-3.5 w-3.5 fill-current" aria-hidden>
+      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+    </svg>
+  )
+}
+
+export async function Projects() {
+  const repos = await getGithubRepos()
+
+  if (repos.length === 0) return null
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+          Projects
+        </h2>
+        <a
+          href="https://github.com/adarshm07?tab=repositories"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+        >
+          View all →
+        </a>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {repos.map((repo) => (
+          <a
+            key={repo.id}
+            href={repo.html_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex flex-col rounded-lg border border-neutral-100 dark:border-neutral-800 p-4 hover:border-green-200 dark:hover:border-green-900 hover:bg-neutral-50 dark:hover:bg-neutral-900/60 transition-all"
+          >
+            <span className="mb-1 font-medium text-sm text-neutral-800 dark:text-neutral-200 group-hover:text-green-700 dark:group-hover:text-green-400 transition-colors truncate">
+              {repo.name}
+            </span>
+
+            {repo.description ? (
+              <span className="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-2 mb-3 flex-1">
+                {repo.description}
+              </span>
+            ) : (
+              <span className="flex-1" />
+            )}
+
+            <div className="flex items-center gap-3 text-xs text-neutral-400 dark:text-neutral-500">
+              {repo.language && (
+                <span className="flex items-center gap-1.5">
+                  <span
+                    className="inline-block h-2.5 w-2.5 rounded-full"
+                    style={{
+                      backgroundColor:
+                        languageColors[repo.language] ?? '#6b7280',
+                    }}
+                  />
+                  {repo.language}
+                </span>
+              )}
+              {repo.stargazers_count > 0 && (
+                <span className="flex items-center gap-1">
+                  <StarIcon />
+                  {repo.stargazers_count}
+                </span>
+              )}
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/lib/github.ts
+++ b/src/app/lib/github.ts
@@ -1,0 +1,60 @@
+export type GithubProfile = {
+  login: string
+  name: string
+  bio: string | null
+  avatar_url: string
+  location: string | null
+  blog: string | null
+  twitter_username: string | null
+  public_repos: number
+  followers: number
+  following: number
+  html_url: string
+}
+
+export type GithubRepo = {
+  id: number
+  name: string
+  description: string | null
+  html_url: string
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  topics: string[]
+  updated_at: string
+  fork: boolean
+}
+
+const USERNAME = 'adarshm07'
+const BASE = 'https://api.github.com'
+const opts: RequestInit = {
+  next: { revalidate: 3600 },
+  headers: { Accept: 'application/vnd.github.v3+json' },
+}
+
+export async function getGithubProfile(): Promise<GithubProfile | null> {
+  try {
+    const res = await fetch(`${BASE}/users/${USERNAME}`, opts)
+    if (!res.ok) return null
+    return res.json() as Promise<GithubProfile>
+  } catch {
+    return null
+  }
+}
+
+export async function getGithubRepos(): Promise<GithubRepo[]> {
+  try {
+    const res = await fetch(
+      `${BASE}/users/${USERNAME}/repos?sort=pushed&per_page=100`,
+      opts
+    )
+    if (!res.ok) return []
+    const repos = (await res.json()) as GithubRepo[]
+    return repos
+      .filter((r) => !r.fork && r.name !== 'adarshm-blog')
+      .sort((a, b) => b.stargazers_count - a.stargazers_count)
+      .slice(0, 6)
+  } catch {
+    return []
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,18 @@
+import { Suspense } from 'react'
 import { BlogPosts } from '@/app/components/posts'
+import { Profile } from '@/app/components/profile'
+import { Projects } from '@/app/components/projects'
 
 export default function Page() {
   return (
     <section className="space-y-12">
-      <div>
-        <h1 className="mb-2 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
-          Hi, I&apos;m{' '}
-          <span className="text-green-600 dark:text-green-500">Adarsh M.</span>
-        </h1>
-        <p className="text-neutral-500 dark:text-neutral-400">
-          JavaScript developer &middot; Kerala, India
-        </p>
-      </div>
+      <Suspense fallback={<ProfileSkeleton />}>
+        <Profile />
+      </Suspense>
+
+      <Suspense fallback={null}>
+        <Projects />
+      </Suspense>
 
       <div>
         <h2 className="mb-4 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
@@ -20,5 +21,18 @@ export default function Page() {
         <BlogPosts />
       </div>
     </section>
+  )
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="flex items-start gap-5 animate-pulse">
+      <div className="h-20 w-20 rounded-full bg-neutral-100 dark:bg-neutral-800 shrink-0" />
+      <div className="flex-1 space-y-2 pt-1">
+        <div className="h-5 w-32 rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="h-4 w-48 rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="h-4 w-24 rounded bg-neutral-100 dark:bg-neutral-800" />
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
- src/app/lib/github.ts: fetch profile + repos from GitHub API (ISR, revalidates every hour; gracefully falls back on API failure)
- src/app/components/profile.tsx: avatar, name, bio, location, repo/ follower counts, GitHub / Twitter / LinkedIn icon links
- src/app/components/projects.tsx: 2-col grid of top repos with language color dots and star counts, links to GitHub
- src/app/page.tsx: home page now has Profile → Projects → Writing sections; Profile wrapped in Suspense with skeleton fallback

LinkedIn links to https://www.linkedin.com/in/adarshm/ (public profile data cannot be fetched due to LinkedIn auth requirements, so it is shown as a social icon link only).

https://claude.ai/code/session_01TDWzR8EgAaZKnwqja9nu6t