### PR TITLE
Redesign home page and blog section with a cleaner minimal layout

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,10 +8,14 @@ export const metadata = {
 export default function Page() {
   return (
     <section>
-      <h1 className="mb-8 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+      <h1 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
         Blog
       </h1>
-      <BlogPosts />
+      <p className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+        Notes on JavaScript, frontend architecture, and things I learn
+        building on the web.
+      </p>
+      <BlogPosts showSummary />
     </section>
   )
 }

--- a/src/app/components/posts.tsx
+++ b/src/app/components/posts.tsx
@@ -1,12 +1,20 @@
 import Link from 'next/link'
 import { formatDate, getBlogPosts } from '@/app/blog/utils'
 
-export function BlogPosts() {
-  const allBlogs = getBlogPosts().sort(
-    (a, b) =>
-      new Date(b.metadata.publishedAt).getTime() -
-      new Date(a.metadata.publishedAt).getTime()
-  )
+export function BlogPosts({
+  limit,
+  showSummary = false,
+}: {
+  limit?: number
+  showSummary?: boolean
+} = {}) {
+  const allBlogs = getBlogPosts()
+    .sort(
+      (a, b) =>
+        new Date(b.metadata.publishedAt).getTime() -
+        new Date(a.metadata.publishedAt).getTime()
+    )
+    .slice(0, limit)
 
   return (
     <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
@@ -14,14 +22,21 @@ export function BlogPosts() {
         <Link
           key={post.slug}
           href={`/blog/${post.slug}`}
-          className="group flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4 py-4 hover:bg-neutral-50 dark:hover:bg-neutral-900/50 -mx-3 px-3 rounded-lg transition-colors"
+          className="group block py-4 -mx-3 px-3 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-900/50 transition-colors"
         >
-          <span className="text-sm text-neutral-400 dark:text-neutral-500 tabular-nums shrink-0">
-            {formatDate(post.metadata.publishedAt, false)}
-          </span>
-          <span className="font-medium text-neutral-800 dark:text-neutral-200 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors">
-            {post.metadata.title}
-          </span>
+          <div className="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
+            <span className="text-sm text-neutral-400 dark:text-neutral-500 tabular-nums shrink-0">
+              {formatDate(post.metadata.publishedAt, false)}
+            </span>
+            <span className="font-medium text-neutral-800 dark:text-neutral-200 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors">
+              {post.metadata.title}
+            </span>
+          </div>
+          {showSummary && post.metadata.summary && (
+            <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400 line-clamp-2">
+              {post.metadata.summary}
+            </p>
+          )}
         </Link>
       ))}
     </div>

--- a/src/app/components/profile.tsx
+++ b/src/app/components/profile.tsx
@@ -31,79 +31,63 @@ export async function Profile() {
   const profile = await getGithubProfile()
 
   const name = profile?.name ?? 'Adarsh M'
-  const bio = profile?.bio ?? '⚡ Learning JS'
-  const location = profile?.location ?? 'Kerala, India'
   const avatarUrl = profile?.avatar_url ?? null
-  const publicRepos = profile?.public_repos ?? 61
-  const followers = profile?.followers ?? 8
   const twitterUsername = profile?.twitter_username ?? 'adarshm07'
   const githubUrl = profile?.html_url ?? 'https://github.com/adarshm07'
 
   return (
-    <div className="flex flex-col sm:flex-row items-start gap-5">
+    <div className="flex flex-col sm:flex-row sm:items-center gap-5">
       {avatarUrl && (
         <Image
           src={avatarUrl}
           alt={name}
-          width={80}
-          height={80}
+          width={64}
+          height={64}
           className="rounded-full ring-2 ring-neutral-100 dark:ring-neutral-800 shrink-0"
           priority
         />
       )}
 
       <div className="flex-1 min-w-0">
-        <h1 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+        <h1 className="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
           {name}
         </h1>
-        <p className="mt-0.5 text-sm text-neutral-500 dark:text-neutral-400">
-          {bio}
-        </p>
-        <p className="mt-0.5 text-sm text-neutral-400 dark:text-neutral-500">
-          {location}
+        <p className="mt-1.5 text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
+          Software engineer based in Kerala, India. I build for the web and
+          write here about JavaScript, frontend architecture, and things I
+          pick up along the way.
         </p>
 
-        <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2">
-          <div className="flex items-center gap-4 text-xs text-neutral-400 dark:text-neutral-500">
-            <span>
-              <strong className="text-neutral-700 dark:text-neutral-300">{publicRepos}</strong> repos
-            </span>
-            <span>
-              <strong className="text-neutral-700 dark:text-neutral-300">{followers}</strong> followers
-            </span>
-          </div>
-
-          <div className="flex items-center gap-3">
+        <div className="mt-3 flex items-center gap-3">
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+            className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+          >
+            <GithubIcon />
+          </a>
+          {twitterUsername && (
             <a
-              href={githubUrl}
+              href={`https://x.com/${twitterUsername}`}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="GitHub"
+              aria-label="X / Twitter"
               className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
             >
-              <GithubIcon />
+              <TwitterIcon />
             </a>
-            {twitterUsername && (
-              <a
-                href={`https://x.com/${twitterUsername}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="X / Twitter"
-                className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
-              >
-                <TwitterIcon />
-              </a>
-            )}
-            <a
-              href={LINKEDIN_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn"
-              className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
-            >
-              <LinkedInIcon />
-            </a>
-          </div>
+          )}
+          <a
+            href={LINKEDIN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="LinkedIn"
+            className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+          >
+            <LinkedInIcon />
+          </a>
         </div>
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,45 @@
 import { Suspense } from 'react'
+import Link from 'next/link'
 import { BlogPosts } from '@/app/components/posts'
 import { Profile } from '@/app/components/profile'
 import { Projects } from '@/app/components/projects'
 
 export default function Page() {
   return (
-    <section className="space-y-12">
+    <section className="space-y-14">
       <Suspense fallback={<ProfileSkeleton />}>
         <Profile />
       </Suspense>
 
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+            Writing
+          </h2>
+          <Link
+            href="/blog"
+            className="text-xs text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+          >
+            View all →
+          </Link>
+        </div>
+        <BlogPosts limit={5} />
+      </div>
+
       <Suspense fallback={null}>
         <Projects />
       </Suspense>
-
-      <div>
-        <h2 className="mb-4 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
-          Writing
-        </h2>
-        <BlogPosts />
-      </div>
     </section>
   )
 }
 
 function ProfileSkeleton() {
   return (
-    <div className="flex items-start gap-5 animate-pulse">
-      <div className="h-20 w-20 rounded-full bg-neutral-100 dark:bg-neutral-800 shrink-0" />
-      <div className="flex-1 space-y-2 pt-1">
-        <div className="h-5 w-32 rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="h-4 w-48 rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="h-4 w-24 rounded bg-neutral-100 dark:bg-neutral-800" />
+    <div className="flex items-center gap-5 animate-pulse">
+      <div className="h-16 w-16 rounded-full bg-neutral-100 dark:bg-neutral-800 shrink-0" />
+      <div className="flex-1 space-y-2">
+        <div className="h-6 w-40 rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="h-4 w-64 rounded bg-neutral-100 dark:bg-neutral-800" />
       </div>
     </div>
   )


### PR DESCRIPTION
Rework the hero into a proper intro (name, short bio, social links)
instead of raw GitHub bio text, reorder the home page so Writing sits
above Projects with a "View all" link, and surface post summaries in
the blog list (compact on home, full on /blog) via a new BlogPosts
limit/showSummary API.