### PR TITLE
Refocus site on DSA/system design writing, add blog topic filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ title: "Post Title"
 publishedAt: "YYYY-MM-DD"
 summary: "Brief description shown in meta tags and RSS"
 image: "/optional-og-image.png"   # optional; falls back to auto-generated OG image
+tags: "DSA, System Design"        # optional; comma-separated, powers the /blog topic filter
 ---
 ```
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,21 +1,62 @@
+import Link from 'next/link'
 import { BlogPosts } from '@/app/components/posts'
+import { getAllTags } from '@/app/blog/utils'
 
 export const metadata = {
   title: 'Blog',
-  description: 'Writing about JavaScript, frontend development, and the web.',
+  description:
+    'Notes on data structures & algorithms, system design, and things I learn along the way.',
 }
 
-export default function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ tag?: string }>
+}) {
+  const { tag } = await searchParams
+  const tags = getAllTags()
+
   return (
     <section>
       <h1 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
         Blog
       </h1>
-      <p className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
-        Notes on JavaScript, frontend architecture, and things I learn
-        building on the web.
+      <p className="mb-6 text-sm text-neutral-500 dark:text-neutral-400">
+        Notes on data structures & algorithms, system design, and things I
+        learn along the way.
       </p>
-      <BlogPosts showSummary />
+
+      {tags.length > 0 && (
+        <div className="mb-8 flex flex-wrap gap-1">
+          <Link
+            href="/blog"
+            className={[
+              'px-3 py-1 rounded-md text-xs transition-colors',
+              !tag
+                ? 'text-neutral-900 dark:text-neutral-50 font-medium bg-neutral-100 dark:bg-neutral-800'
+                : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-900',
+            ].join(' ')}
+          >
+            All
+          </Link>
+          {tags.map((t) => (
+            <Link
+              key={t}
+              href={`/blog?tag=${encodeURIComponent(t)}`}
+              className={[
+                'px-3 py-1 rounded-md text-xs transition-colors',
+                tag === t
+                  ? 'text-neutral-900 dark:text-neutral-50 font-medium bg-neutral-100 dark:bg-neutral-800'
+                  : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-900',
+              ].join(' ')}
+            >
+              {t}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <BlogPosts showSummary tag={tag} />
     </section>
   )
 }

--- a/src/app/blog/posts/micro-frontend-using-nextjs.mdx
+++ b/src/app/blog/posts/micro-frontend-using-nextjs.mdx
@@ -2,6 +2,7 @@
 title: "How to Create Your First Micro-Frontend Using NextJS"
 publishedAt: "2024-09-22"
 summary: "Learn how to build your first micro-frontend architecture using NextJS, exploring the benefits of modular development and strategies for seamless integration in modern web applications."
+tags: "System Design"
 ---
 
 This tutorial focuses on creating a micro-frontend architecture using NextJS and its built-in features. If you're looking to implement micro-frontends with different technologies, this post may not be directly applicable, but it can still provide valuable insights and ideas.

--- a/src/app/blog/utils.ts
+++ b/src/app/blog/utils.ts
@@ -6,6 +6,7 @@ type Metadata = {
   publishedAt: string
   summary: string
   image?: string
+  tags?: string[]
 }
 
 function parseFrontmatter(fileContent: string) {
@@ -18,9 +19,18 @@ function parseFrontmatter(fileContent: string) {
 
   frontMatterLines.forEach((line) => {
     let [key, ...valueArr] = line.split(': ')
+    let trimmedKey = key.trim()
     let value = valueArr.join(': ').trim()
     value = value.replace(/^['"](.*)['"]$/, '$1') // Remove quotes
-    metadata[key.trim() as keyof Metadata] = value
+
+    if (trimmedKey === 'tags') {
+      metadata.tags = value
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+    } else {
+      metadata[trimmedKey as keyof Omit<Metadata, 'tags'>] = value
+    }
   })
 
   return { metadata: metadata as Metadata, content }
@@ -51,6 +61,13 @@ function getMDXData(dir: string) {
 
 export function getBlogPosts() {
   return getMDXData(path.join(process.cwd(), 'src', 'app', 'blog', 'posts'))
+}
+
+export function getAllTags() {
+  let posts = getBlogPosts()
+  let tags = new Set<string>()
+  posts.forEach((post) => post.metadata.tags?.forEach((tag) => tags.add(tag)))
+  return Array.from(tags).sort()
 }
 
 export function formatDate(date: string, includeRelative = false) {

--- a/src/app/components/posts.tsx
+++ b/src/app/components/posts.tsx
@@ -4,11 +4,14 @@ import { formatDate, getBlogPosts } from '@/app/blog/utils'
 export function BlogPosts({
   limit,
   showSummary = false,
+  tag,
 }: {
   limit?: number
   showSummary?: boolean
+  tag?: string
 } = {}) {
   const allBlogs = getBlogPosts()
+    .filter((post) => !tag || post.metadata.tags?.includes(tag))
     .sort(
       (a, b) =>
         new Date(b.metadata.publishedAt).getTime() -
@@ -36,6 +39,18 @@ export function BlogPosts({
             <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400 line-clamp-2">
               {post.metadata.summary}
             </p>
+          )}
+          {showSummary && post.metadata.tags && post.metadata.tags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {post.metadata.tags.map((t) => (
+                <span
+                  key={t}
+                  className="text-xs text-neutral-400 dark:text-neutral-500"
+                >
+                  #{t}
+                </span>
+              ))}
+            </div>
           )}
         </Link>
       ))}

--- a/src/app/components/profile.tsx
+++ b/src/app/components/profile.tsx
@@ -53,8 +53,8 @@ export async function Profile() {
           {name}
         </h1>
         <p className="mt-1.5 text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
-          Software engineer based in Kerala, India. I build for the web and
-          write here about JavaScript, frontend architecture, and things I
+          Software engineer based in Kerala, India. I write here as I learn —
+          data structures & algorithms, system design, and other things I
           pick up along the way.
         </p>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from 'react'
 import Link from 'next/link'
 import { BlogPosts } from '@/app/components/posts'
 import { Profile } from '@/app/components/profile'
-import { Projects } from '@/app/components/projects'
 
 export default function Page() {
   return (
@@ -25,10 +24,6 @@ export default function Page() {
         </div>
         <BlogPosts limit={5} />
       </div>
-
-      <Suspense fallback={null}>
-        <Projects />
-      </Suspense>
     </section>
   )
 }


### PR DESCRIPTION
Hide the homepage Projects section for now, update the bio to reflect
the learning-in-public focus, and let posts declare comma-separated
tags in frontmatter that power topic filter pills on /blog.