### PR TITLE
Add reading progress bar and table of contents to blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from 'next/navigation'
 import { CustomMDX } from '@/app/components/mdx'
+import { ReadingProgress } from '@/app/components/reading-progress'
+import { TableOfContents } from '@/app/components/toc'
 import { formatDate, getBlogPosts } from '@/app/blog/utils'
 import { baseUrl } from '@/app/sitemap'
 
@@ -53,6 +55,8 @@ export default async function Blog({
 
   return (
     <section>
+      <ReadingProgress />
+      <TableOfContents />
       <script
         type="application/ld+json"
         suppressHydrationWarning

--- a/src/app/components/reading-progress.tsx
+++ b/src/app/components/reading-progress.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function ReadingProgress() {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    const article = document.querySelector('article')
+    if (!article) return
+
+    function updateProgress() {
+      const { top, height } = article!.getBoundingClientRect()
+      const total = height - window.innerHeight
+      const scrolled = -top
+      const pct = total > 0 ? Math.min(Math.max(scrolled / total, 0), 1) : 0
+      setProgress(pct)
+    }
+
+    updateProgress()
+    window.addEventListener('scroll', updateProgress, { passive: true })
+    window.addEventListener('resize', updateProgress)
+    return () => {
+      window.removeEventListener('scroll', updateProgress)
+      window.removeEventListener('resize', updateProgress)
+    }
+  }, [])
+
+  return (
+    <div className="fixed top-0 left-0 right-0 h-0.5 z-50">
+      <div
+        className="h-full bg-green-600 dark:bg-green-500"
+        style={{ width: `${progress * 100}%` }}
+      />
+    </div>
+  )
+}

--- a/src/app/components/toc.tsx
+++ b/src/app/components/toc.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type HeadingItem = {
+  id: string
+  text: string
+  level: number
+}
+
+export function TableOfContents() {
+  const [headings, setHeadings] = useState<HeadingItem[]>([])
+  const [activeId, setActiveId] = useState('')
+
+  useEffect(() => {
+    const elements = Array.from(
+      document.querySelectorAll<HTMLElement>('article h2, article h3')
+    )
+    setHeadings(
+      elements.map((el) => ({
+        id: el.id,
+        text: el.textContent?.replace(/^#/, '').trim() ?? '',
+        level: el.tagName === 'H3' ? 3 : 2,
+      }))
+    )
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.find((entry) => entry.isIntersecting)
+        if (visible) setActiveId(visible.target.id)
+      },
+      { rootMargin: '-80px 0px -70% 0px' }
+    )
+
+    elements.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
+
+  if (headings.length < 2) return null
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className="hidden xl:block fixed left-[max(1rem,calc(50%-608px))] top-32 w-52 max-h-[70vh] overflow-y-auto"
+    >
+      <p className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+        On this page
+      </p>
+      <ul className="space-y-2">
+        {headings.map((heading) => (
+          <li key={heading.id} className={heading.level === 3 ? 'ml-3' : ''}>
+            <a
+              href={`#${heading.id}`}
+              className={[
+                'block border-l-2 pl-3 text-xs leading-relaxed transition-colors',
+                activeId === heading.id
+                  ? 'border-green-600 text-green-700 dark:text-green-400 font-medium'
+                  : 'border-neutral-100 dark:border-neutral-800 text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200',
+              ].join(' ')}
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -43,6 +43,17 @@ html {
   min-width: 360px;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+.prose h2,
+.prose h3 {
+  scroll-margin-top: 2rem;
+}
+
 /* ── Prose ───────────────────────────────────────────────── */
 
 .prose .anchor {


### PR DESCRIPTION
Track scroll position through the article with a thin top progress bar, and add a fixed left-margin TOC (h2/h3) on wide screens that highlights the current section via IntersectionObserver and jumps to it on click. Code blocks were already syntax-highlighted via sugar-high.