### PR TITLE
Add reading time, share links, and related posts to blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,8 @@ import { notFound } from 'next/navigation'
 import { CustomMDX } from '@/app/components/mdx'
 import { ReadingProgress } from '@/app/components/reading-progress'
 import { TableOfContents } from '@/app/components/toc'
-import { formatDate, getBlogPosts } from '@/app/blog/utils'
+import { PostSidebar } from '@/app/components/post-sidebar'
+import { formatDate, getBlogPosts, getReadingTime } from '@/app/blog/utils'
 import { baseUrl } from '@/app/sitemap'
 
 export async function generateStaticParams() {
@@ -53,10 +54,14 @@ export default async function Blog({
 
   if (!post) notFound()
 
+  const readingTime = getReadingTime(post.content)
+  const url = `${baseUrl}/blog/${post.slug}`
+
   return (
     <section>
       <ReadingProgress />
       <TableOfContents />
+      <PostSidebar slug={post.slug} title={post.metadata.title} url={url} />
       <script
         type="application/ld+json"
         suppressHydrationWarning
@@ -85,7 +90,7 @@ export default async function Blog({
           {post.metadata.title}
         </h1>
         <p className="text-sm text-neutral-500 dark:text-neutral-400">
-          {formatDate(post.metadata.publishedAt)}
+          {formatDate(post.metadata.publishedAt)} · {readingTime} min read
         </p>
       </div>
 

--- a/src/app/blog/utils.ts
+++ b/src/app/blog/utils.ts
@@ -70,6 +70,35 @@ export function getAllTags() {
   return Array.from(tags).sort()
 }
 
+export function getReadingTime(content: string) {
+  let words = content.trim().split(/\s+/).length
+  return Math.max(1, Math.round(words / 200))
+}
+
+export function getRelatedPosts(slug: string, limit = 3) {
+  let posts = getBlogPosts()
+  let current = posts.find((post) => post.slug === slug)
+  if (!current?.metadata.tags?.length) return []
+
+  return posts
+    .filter((post) => post.slug !== slug)
+    .map((post) => ({
+      post,
+      overlap: post.metadata.tags?.filter((tag) =>
+        current!.metadata.tags!.includes(tag)
+      ).length ?? 0,
+    }))
+    .filter(({ overlap }) => overlap > 0)
+    .sort(
+      (a, b) =>
+        b.overlap - a.overlap ||
+        new Date(b.post.metadata.publishedAt).getTime() -
+          new Date(a.post.metadata.publishedAt).getTime()
+    )
+    .slice(0, limit)
+    .map(({ post }) => post)
+}
+
 export function formatDate(date: string, includeRelative = false) {
   let currentDate = new Date()
   if (!date.includes('T')) {

--- a/src/app/components/copy-link-button.tsx
+++ b/src/app/components/copy-link-button.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState } from 'react'
+
+export function CopyLinkButton({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-left text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+    >
+      {copied ? 'Copied!' : 'Copy link'}
+    </button>
+  )
+}

--- a/src/app/components/post-sidebar.tsx
+++ b/src/app/components/post-sidebar.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link'
+import { CopyLinkButton } from '@/app/components/copy-link-button'
+import { getRelatedPosts } from '@/app/blog/utils'
+
+export function PostSidebar({
+  slug,
+  title,
+  url,
+}: {
+  slug: string
+  title: string
+  url: string
+}) {
+  const related = getRelatedPosts(slug)
+
+  return (
+    <aside className="hidden xl:block fixed right-[max(1rem,calc(50%-608px))] top-32 w-52">
+      <div className="mb-8">
+        <p className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+          Share
+        </p>
+        <div className="flex flex-col gap-2 text-xs">
+          <a
+            href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+          >
+            Share on X
+          </a>
+          <a
+            href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+          >
+            Share on LinkedIn
+          </a>
+          <CopyLinkButton url={url} />
+        </div>
+      </div>
+
+      {related.length > 0 && (
+        <div>
+          <p className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+            Related
+          </p>
+          <ul className="space-y-3 text-xs">
+            {related.map((post) => (
+              <li key={post.slug}>
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="block leading-snug text-neutral-600 dark:text-neutral-300 hover:text-green-700 dark:hover:text-green-400 transition-colors"
+                >
+                  {post.metadata.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  )
+}


### PR DESCRIPTION
Show estimated reading time next to the published date, and add a right-margin sidebar (mirroring the left TOC) with share links for X/LinkedIn, a copy-link button, and related posts computed from shared tags.