### PR TITLE
Add 10 animated posts and upgrade prototype chain animation

### DIFF
--- a/src/app/blog/posts/bit-manipulation-fundamentals.mdx
+++ b/src/app/blog/posts/bit-manipulation-fundamentals.mdx
@@ -1,0 +1,144 @@
+---
+title: "Bit Manipulation Fundamentals"
+publishedAt: "2026-07-11"
+summary: "The operators every developer half-remembers — AND, OR, XOR, shifts — and the handful of tricks that turn them into fast, elegant solutions."
+tags: "DSA"
+---
+
+Bitwise operations feel like a relic from a lower-level era, but they show
+up constantly: flags and permissions, hashing, graphics, compression, and a
+whole genre of interview problems. The operators are simple; the leverage
+comes from a few recurring tricks. Let's build them up.
+
+## The operators
+
+Every integer is a row of bits. The bitwise operators work on those bits in
+parallel:
+
+<table>
+  <thead>
+    <tr>
+      <th>Op</th>
+      <th>Name</th>
+      <th>Rule per bit</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>&</code></td>
+      <td>AND</td>
+      <td>1 only if both bits are 1</td>
+    </tr>
+    <tr>
+      <td><code>|</code></td>
+      <td>OR</td>
+      <td>1 if either bit is 1</td>
+    </tr>
+    <tr>
+      <td><code>^</code></td>
+      <td>XOR</td>
+      <td>1 if the bits differ</td>
+    </tr>
+    <tr>
+      <td><code>~</code></td>
+      <td>NOT</td>
+      <td>flips every bit</td>
+    </tr>
+    <tr>
+      <td><code>&lt;&lt;</code></td>
+      <td>left shift</td>
+      <td>shift bits up (× 2 per step)</td>
+    </tr>
+    <tr>
+      <td><code>&gt;&gt;</code></td>
+      <td>right shift</td>
+      <td>shift bits down (÷ 2 per step)</td>
+    </tr>
+  </tbody>
+</table>
+
+XOR is the interesting one. It's "difference," and it has magic properties:
+`x ^ 0 === x`, `x ^ x === 0`, and it's its own inverse. Those three facts
+power a surprising number of tricks.
+
+## Reading, setting, and clearing a bit
+
+The basic vocabulary — to work with bit `i`, build a **mask** `1 << i` (a
+number with a single 1 in position `i`) and combine it:
+
+```javascript
+const isSet   = (n, i) => (n & (1 << i)) !== 0; // test bit i
+const setBit  = (n, i) => n | (1 << i);         // force bit i to 1
+const clear   = (n, i) => n & ~(1 << i);        // force bit i to 0
+const toggle  = (n, i) => n ^ (1 << i);         // flip bit i
+```
+
+This is exactly how permission flags work: `READ | WRITE` packs multiple
+booleans into one integer, and `flags & WRITE` checks one.
+
+## Trick 1: n & (n − 1) clears the lowest set bit
+
+Subtracting 1 flips the lowest `1` bit to `0` and turns everything below it
+to `1`; AND-ing with the original wipes out that lowest bit and everything
+under it. Repeat until zero and you've counted the set bits — running once
+per *set* bit, not once per bit:
+
+<BitVisualizer />
+
+```javascript
+function countBits(n) {
+  let count = 0;
+  while (n) {
+    n &= n - 1;   // remove the lowest set bit
+    count++;
+  }
+  return count;
+}
+```
+
+For a number with only a few bits set, this is far faster than checking all
+32 positions. (`n & (n - 1)) === 0` is also the classic power-of-two test —
+a power of two has exactly one set bit.)
+
+## Trick 2: XOR finds the unique element
+
+Every number XOR'd with itself is 0, and XOR is commutative. So if every
+value in an array appears twice except one, XOR-ing them all together
+cancels the pairs and leaves the loner — `O(n)` time, `O(1)` space, no hash
+set:
+
+```javascript
+function singleNumber(nums) {
+  return nums.reduce((acc, n) => acc ^ n, 0);
+}
+singleNumber([4, 1, 2, 1, 2]); // 4
+```
+
+The same idea swaps two variables without a temp (`a ^= b; b ^= a; a ^= b`)
+and detects the one changed bit between two numbers (`a ^ b`).
+
+## A warning specific to JavaScript
+
+JavaScript's bitwise operators coerce their operands to **32-bit signed
+integers**, even though numbers are normally 64-bit floats. That has two
+consequences:
+
+- Bit operations silently break for values above 2³¹ − 1. For big integers,
+  use `BigInt` (whose bitwise operators have no width limit).
+- `>>` is an *arithmetic* shift (preserves the sign bit); `>>>` is a
+  *logical* shift (fills with zeros). Mixing them up on negative numbers is
+  a classic bug.
+
+```javascript
+-8 >> 1;   // -4  (sign preserved)
+-8 >>> 1;  // 2147483644  (treated as unsigned)
+```
+
+## Wrap-up
+
+Bit manipulation is a small vocabulary — masks with `1 << i`, and the AND /
+OR / XOR / shift operators — plus a few tricks worth memorizing:
+`n & (n-1)` strips the lowest set bit, XOR cancels pairs and finds the odd
+one out, and a single set bit means a power of two. Reach for them when you
+need packed flags or a constant-space answer, and mind JavaScript's 32-bit
+coercion.

--- a/src/app/blog/posts/consistent-hashing.mdx
+++ b/src/app/blog/posts/consistent-hashing.mdx
@@ -1,0 +1,148 @@
+---
+title: "Consistent Hashing: Scaling Without Reshuffling Everything"
+publishedAt: "2026-07-12"
+summary: "Why `hash % N` falls apart the moment you add a server, and how consistent hashing moves only a fraction of your keys when the cluster changes."
+tags: "System Design"
+---
+
+You have data — cache entries, sessions, database rows — and a set of
+servers to spread it across. The question is deceptively simple: *given a
+key, which server owns it?* The naive answer works fine until the day you
+add or remove a server, at which point it quietly melts down. Consistent
+hashing is the fix, and it's behind Redis Cluster, Cassandra, DynamoDB,
+CDNs, and load balancers everywhere.
+
+## The naive approach and why it breaks
+
+The obvious mapping is modulo:
+
+```javascript
+function serverFor(key, serverCount) {
+  return hash(key) % serverCount;
+}
+```
+
+With 4 servers, key `hash = 1234` goes to server `1234 % 4 = 2`. Clean and
+fast. The problem is the `% N`: change `N` and *almost every key* maps
+somewhere new.
+
+Go from 4 servers to 5 and `1234 % 5 = 4` — a different server. Do the math
+across all keys and roughly **80% of them relocate**. For a cache, that's a
+mass miss storm: nearly everything has to be re-fetched from the origin at
+once. For a database, it's a giant, coordinated data migration just to add
+one node. The system is punished for growing.
+
+## The ring
+
+Consistent hashing changes the geometry. Instead of mapping keys to `N`
+slots, hash both **keys and servers** onto the same circular space (say
+0 to 2³² − 1, wrapped into a ring). To find a key's owner, start at the
+key's position and walk **clockwise** to the first server you hit:
+
+<ConsistentHashRingVisualizer />
+
+The crucial property is in the last steps of that animation. When you add
+server **D**, the only keys that move are the ones sitting in the arc
+between D and the server that *used* to cover that stretch. Every other key
+still walks clockwise to the same server as before. Adding a node into an
+`N`-node ring relocates roughly `1/N` of the keys — not 80%.
+
+```javascript
+class HashRing {
+  constructor() { this.ring = []; } // sorted [{ hash, server }]
+
+  addServer(server) {
+    this.ring.push({ hash: hash(server), server });
+    this.ring.sort((a, b) => a.hash - b.hash);
+  }
+
+  serverFor(key) {
+    const h = hash(key);
+    // first server clockwise (hash >= h), else wrap to the first
+    for (const node of this.ring) {
+      if (node.hash >= h) return node.server;
+    }
+    return this.ring[0].server; // wrapped past the top of the ring
+  }
+}
+```
+
+Removing a server is the mirror image: only *its* keys move, and they go to
+the next server clockwise. Everyone else is untouched.
+
+## The uneven-load problem, and virtual nodes
+
+There's a catch. With only a few servers placed randomly on the ring, the
+arcs between them are uneven — one server might own a huge slice of the
+circle and get hammered while another sits idle. And when a server dies,
+its *entire* load dumps onto the single next server, not the whole cluster.
+
+The fix is **virtual nodes**: place each physical server at many points
+around the ring (say 100–200 hashes per server, using
+`hash(server + "#" + i)`). Now each physical server owns many small arcs
+scattered around the circle instead of one big one. Two benefits:
+
+- Load evens out — the law of large numbers smooths the arc sizes.
+- When a server fails, its many small arcs spill onto *many* different
+  neighbours, spreading the extra load across the whole cluster instead of
+  crushing one node.
+
+```javascript
+addServer(server, vnodes = 150) {
+  for (let i = 0; i < vnodes; i++) {
+    this.ring.push({ hash: hash(`${server}#${i}`), server });
+  }
+  this.ring.sort((a, b) => a.hash - b.hash);
+}
+```
+
+Virtually every real implementation uses virtual nodes; the plain ring is
+just the teaching version.
+
+## The trade-offs
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>hash % N</th>
+      <th>Consistent hashing</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Lookup cost</td>
+      <td>O(1)</td>
+      <td>O(log N) (binary search the ring)</td>
+    </tr>
+    <tr>
+      <td>Keys moved when adding a node</td>
+      <td>~all of them</td>
+      <td>~1/N of them</td>
+    </tr>
+    <tr>
+      <td>Even load</td>
+      <td>Yes, automatically</td>
+      <td>Needs virtual nodes</td>
+    </tr>
+    <tr>
+      <td>Complexity</td>
+      <td>Trivial</td>
+      <td>Moderate</td>
+    </tr>
+  </tbody>
+</table>
+
+If your server set truly never changes, `% N` is fine — don't over-engineer.
+Consistent hashing earns its complexity precisely when nodes come and go:
+autoscaling caches, sharded databases, and any cluster where a single
+deploy shouldn't invalidate everything.
+
+## Wrap-up
+
+`hash % N` ties every key's location to the exact server count, so changing
+that count reshuffles nearly everything. Consistent hashing puts keys and
+servers on a ring and assigns each key to the next server clockwise, so a
+membership change disturbs only a thin slice of keys — and virtual nodes
+keep that slice evenly spread. It's the standard answer to "how do I add a
+server without a stampede?"

--- a/src/app/blog/posts/dynamic-programming-intro.mdx
+++ b/src/app/blog/posts/dynamic-programming-intro.mdx
@@ -1,0 +1,146 @@
+---
+title: "Dynamic Programming: From Memoization to Tables"
+publishedAt: "2026-07-09"
+summary: "DP is not a scary black box — it's recursion that stops repeating itself. Follow one problem from exponential recursion to a linear table, one cell at a time."
+tags: "DSA"
+---
+
+Dynamic programming has a reputation for being hard, but the core idea is
+almost embarrassingly simple: **if you're solving the same subproblem more
+than once, solve it once and write the answer down.** Everything else —
+memoization, tabulation, the mysterious tables — is bookkeeping around that
+one idea.
+
+## The problem: recursion that repeats itself
+
+Count the ways to climb `n` stairs taking 1 or 2 steps at a time. The
+recursive definition is natural — to reach step `n`, you came from `n-1`
+(one step) or `n-2` (two steps):
+
+```javascript
+function climb(n) {
+  if (n <= 1) return 1;
+  return climb(n - 1) + climb(n - 2);
+}
+```
+
+Clean, correct, and catastrophically slow. `climb(5)` calls `climb(3)`
+twice, `climb(2)` three times, and so on — the call tree branches
+exponentially. `climb(50)` would make over a billion calls, most of them
+recomputing answers already found elsewhere in the tree. This is `O(2ⁿ)`.
+
+## Fix #1: memoization (top-down)
+
+The subproblems repeat, so cache them. The first time you compute
+`climb(k)`, store it; every later request is a lookup:
+
+```javascript
+function climb(n, memo = {}) {
+  if (n <= 1) return 1;
+  if (n in memo) return memo[n];      // already solved
+  memo[n] = climb(n - 1) + climb(n - 2);
+  return memo[n];
+}
+```
+
+That one cache collapses the exponential tree into `O(n)`: each subproblem
+is computed exactly once, then reused. This is **memoization** — keep the
+recursion, just stop repeating work. It's called *top-down* because you
+start from the answer you want and recurse toward the base cases.
+
+## Fix #2: tabulation (bottom-up)
+
+If we're going to solve every subproblem from `0` to `n` anyway, why
+recurse at all? Start at the base cases and fill an array forward, each
+entry built from ones already computed:
+
+<DPTableVisualizer />
+
+```javascript
+function climb(n) {
+  const ways = new Array(n + 1);
+  ways[0] = 1;
+  ways[1] = 1;
+  for (let i = 2; i <= n; i++) {
+    ways[i] = ways[i - 1] + ways[i - 2]; // reuse two finished answers
+  }
+  return ways[n];
+}
+```
+
+Same `O(n)` time, no recursion, no call-stack risk. This is **tabulation** —
+*bottom-up*. The table filling left to right is the animation above.
+
+## The two things every DP problem needs
+
+To turn a problem into DP, you're hunting for two properties:
+
+- **Overlapping subproblems** — the same smaller problems come up again and
+  again. (If they don't, caching buys nothing — that's plain divide and
+  conquer.)
+- **Optimal substructure** — the answer to the big problem is built from
+  answers to smaller ones. (For stairs: ways to reach `n` is exactly the
+  sum of ways to reach `n-1` and `n-2`.)
+
+The hard part of DP is rarely the code — it's finding the **recurrence**:
+the equation that expresses one state in terms of smaller states. Once you
+have that, memoization and tabulation are mechanical translations of it.
+
+## Squeezing the space
+
+Look at the loop: `ways[i]` only ever reads the previous two entries. We
+don't need the whole array — two variables suffice:
+
+```javascript
+function climb(n) {
+  let prev = 1, curr = 1;
+  for (let i = 2; i <= n; i++) {
+    [prev, curr] = [curr, prev + curr];
+  }
+  return curr;
+}
+```
+
+`O(1)` space. This "only keep the window of state you actually reference"
+trick is common once you have a working table.
+
+## Memoization vs. tabulation
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Memoization (top-down)</th>
+      <th>Tabulation (bottom-up)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Shape</td>
+      <td>Recursion + cache</td>
+      <td>Loop + array</td>
+    </tr>
+    <tr>
+      <td>Computes</td>
+      <td>Only subproblems it needs</td>
+      <td>Every subproblem, in order</td>
+    </tr>
+    <tr>
+      <td>Risk</td>
+      <td>Stack overflow if deep</td>
+      <td>None (no recursion)</td>
+    </tr>
+    <tr>
+      <td>Best when</td>
+      <td>Sparse / unclear which states matter</td>
+      <td>All states needed; want O(1) space tricks</td>
+    </tr>
+  </tbody>
+</table>
+
+## Wrap-up
+
+DP is recursion with a memory. Write the honest recursive solution first,
+notice it recomputes subproblems, then either cache them (top-down) or fill
+a table of them in order (bottom-up). Find the recurrence and the rest
+writes itself.

--- a/src/app/blog/posts/graph-traversal-bfs-dfs.mdx
+++ b/src/app/blog/posts/graph-traversal-bfs-dfs.mdx
@@ -1,0 +1,124 @@
+---
+title: "Graph Traversal: BFS and DFS Side by Side"
+publishedAt: "2026-07-09"
+summary: "Breadth-first and depth-first search are the same algorithm with one data structure swapped. See both walk the same graph, and learn which to reach for."
+tags: "DSA"
+---
+
+Almost every graph problem — shortest paths, connectivity, cycle
+detection, topological sort — is built on one of two traversals: **breadth-first
+search (BFS)** or **depth-first search (DFS)**. The remarkable thing is how
+similar they are. They differ by a single choice: what container holds the
+nodes you've discovered but not yet processed.
+
+## BFS: explore level by level
+
+BFS uses a **queue** (first-in, first-out). You visit a node, enqueue all
+its neighbours, then process them in the order they were added — so you
+finish everything one hop away before anything two hops away. It fans out
+in rings:
+
+<GraphBFSVisualizer />
+
+```javascript
+function bfs(graph, start) {
+  const visited = new Set([start]);
+  const queue = [start];
+
+  while (queue.length) {
+    const node = queue.shift();     // take from the front
+    visit(node);
+    for (const next of graph[node]) {
+      if (!visited.has(next)) {
+        visited.add(next);          // mark on enqueue, not on visit
+        queue.push(next);           // add to the back
+      }
+    }
+  }
+}
+```
+
+Because BFS reaches nodes in order of distance from the start, it finds the
+**shortest path in an unweighted graph** for free — the first time you see
+a node is via a shortest route.
+
+> Mark nodes visited *when you enqueue them*, not when you dequeue them.
+> Otherwise a node with two neighbours already in the queue gets added
+> twice.
+
+## DFS: dive deep, then backtrack
+
+DFS uses a **stack** (last-in, first-out) — usually the call stack, via
+recursion. You follow one path as far as it goes, hit a dead end, back up,
+and try the next branch. It plunges down each branch to the bottom before
+exploring siblings:
+
+<GraphDFSVisualizer />
+
+```javascript
+function dfs(graph, node, visited = new Set()) {
+  if (visited.has(node)) return;
+  visited.add(node);
+  visit(node);
+  for (const next of graph[node]) {
+    dfs(graph, next, visited);      // recurse = push onto the call stack
+  }
+}
+```
+
+Swap the queue for a stack and BFS *becomes* DFS — that's the whole
+difference. The queue's FIFO order spreads outward; the stack's LIFO order
+drives downward.
+
+## Which one to use
+
+<table>
+  <thead>
+    <tr>
+      <th>You want…</th>
+      <th>Use</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Shortest path in an unweighted graph</td>
+      <td>BFS</td>
+    </tr>
+    <tr>
+      <td>"Fewest steps / nearest" anything</td>
+      <td>BFS</td>
+    </tr>
+    <tr>
+      <td>Detecting cycles, topological sort</td>
+      <td>DFS</td>
+    </tr>
+    <tr>
+      <td>Exploring all paths, backtracking</td>
+      <td>DFS</td>
+    </tr>
+    <tr>
+      <td>Graph so deep recursion might overflow</td>
+      <td>BFS (or iterative DFS)</td>
+    </tr>
+  </tbody>
+</table>
+
+Both run in **O(V + E)** — every vertex and every edge is touched once. The
+difference is memory shape: BFS's queue can hold an entire level at once
+(wide graphs cost memory), while DFS's stack is only as deep as the longest
+path (deep graphs risk stack overflow).
+
+## The one bug that catches everyone
+
+For both traversals, the `visited` set is what stops infinite loops when
+the graph has cycles. A tree has no cycles so you can sometimes skip it —
+but a general graph will loop forever without it. When a "why is this
+hanging?" bug shows up in graph code, a missing or mis-timed `visited`
+check is the first thing to look at.
+
+## Wrap-up
+
+BFS and DFS are one algorithm parameterized by a container: a queue gives
+you level-order and shortest paths, a stack gives you deep-first and
+backtracking. Learn them as a pair, remember to mark nodes visited, and a
+whole category of graph problems opens up.

--- a/src/app/blog/posts/heaps-and-priority-queues.mdx
+++ b/src/app/blog/posts/heaps-and-priority-queues.mdx
@@ -1,0 +1,153 @@
+---
+title: "Heaps and the Priority Queue"
+publishedAt: "2026-07-10"
+summary: "How a heap keeps the smallest (or largest) element one lookup away, why it's stored in a plain array, and the sift-up/sift-down operations that keep it valid."
+tags: "DSA"
+---
+
+When you need "the smallest thing right now," over and over, while the set
+keeps changing — a heap is the data structure. It's what powers priority
+queues, Dijkstra's algorithm, event schedulers, and the "top K" family of
+problems. And despite looking like a tree, it lives in a flat array.
+
+## What a heap guarantees
+
+A **binary heap** is a complete binary tree with one rule, the *heap
+property*:
+
+- In a **min-heap**, every parent is ≤ its children. The minimum is always
+  at the root.
+- In a **max-heap**, every parent is ≥ its children. The maximum is at the
+  root.
+
+That's a weaker promise than a sorted array — siblings have no defined
+order, and the structure isn't fully sorted. But it's exactly enough to
+make "peek at the extreme" an `O(1)` lookup, while insert and remove stay
+`O(log n)`. A sorted array gives `O(1)` peek too, but `O(n)` inserts; a
+heap is the sweet spot when both operations matter.
+
+## The array trick
+
+A heap doesn't use node objects and pointers. Because it's always a
+*complete* tree (filled left to right, no gaps), you can store it in an
+array and compute relationships with arithmetic:
+
+```javascript
+// for a node at index i:
+parent = (i - 1) >> 1;   // floor((i-1)/2)
+left   = 2 * i + 1;
+right  = 2 * i + 2;
+```
+
+No pointers, great cache locality, and the "next open slot" is just
+`array.length`. The tree in the animation below and the array underneath it
+are the same thing.
+
+## Insert: add at the end, sift up
+
+To insert, drop the new value in the next open slot (keeping the tree
+complete), then **sift up**: while it's smaller than its parent, swap them.
+It bubbles up until the heap property holds again:
+
+<HeapVisualizer />
+
+```javascript
+class MinHeap {
+  constructor() { this.h = []; }
+
+  push(value) {
+    this.h.push(value);
+    let i = this.h.length - 1;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (this.h[parent] <= this.h[i]) break; // property holds — stop
+      [this.h[parent], this.h[i]] = [this.h[i], this.h[parent]];
+      i = parent;
+    }
+  }
+}
+```
+
+The value climbs at most the height of the tree — `O(log n)` swaps.
+
+## Remove the min: swap, shrink, sift down
+
+The minimum is at index 0, but you can't just delete it — that would leave
+a hole at the root. The trick: move the *last* element to the root, shrink
+the array, then **sift down**, swapping the root with its smaller child
+until order is restored:
+
+```javascript
+pop() {
+  const min = this.h[0];
+  const last = this.h.pop();
+  if (this.h.length) {
+    this.h[0] = last;
+    let i = 0;
+    const n = this.h.length;
+    while (true) {
+      let smallest = i;
+      const l = 2 * i + 1, r = 2 * i + 2;
+      if (l < n && this.h[l] < this.h[smallest]) smallest = l;
+      if (r < n && this.h[r] < this.h[smallest]) smallest = r;
+      if (smallest === i) break;
+      [this.h[i], this.h[smallest]] = [this.h[smallest], this.h[i]];
+      i = smallest;
+    }
+  }
+  return min;
+}
+```
+
+Again `O(log n)` — one swap per level as the misplaced value settles down.
+
+## Cost summary
+
+<table>
+  <thead>
+    <tr>
+      <th>Operation</th>
+      <th>Time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>peek (min / max)</td>
+      <td>O(1)</td>
+    </tr>
+    <tr>
+      <td>push (insert)</td>
+      <td>O(log n)</td>
+    </tr>
+    <tr>
+      <td>pop (remove extreme)</td>
+      <td>O(log n)</td>
+    </tr>
+    <tr>
+      <td>build heap from n items</td>
+      <td>O(n)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Where you'll use it
+
+- **Priority queues** — process the most urgent job first.
+- **Dijkstra / A\*** — repeatedly pull the nearest unvisited node.
+- **Top K elements** — keep a size-K heap and evict the extreme; `O(n log k)`
+  instead of sorting everything.
+- **Merge K sorted lists** — a heap of the K front elements.
+- **Streaming median** — one max-heap and one min-heap balanced against
+  each other.
+
+JavaScript has no built-in heap, so you'll often hand-roll one like the
+above — or reach for a library. Most other languages ship one
+(`heapq` in Python, `PriorityQueue` in Java).
+
+## Wrap-up
+
+A heap keeps one specific element — the min or the max — perpetually one
+lookup away, at the price of `O(log n)` inserts and removes. Store it in an
+array, restore the heap property by sifting up on insert and down on
+remove, and you've got the engine behind priority queues and a whole class
+of "give me the next best thing" problems.

--- a/src/app/blog/posts/javascript-generators-and-iterators.mdx
+++ b/src/app/blog/posts/javascript-generators-and-iterators.mdx
@@ -1,0 +1,141 @@
+---
+title: "Generators and Iterators: Functions That Pause"
+publishedAt: "2026-07-12"
+summary: "The protocol behind for...of, the spread operator, and async/await — plus generator functions, which can pause mid-execution and resume exactly where they left off."
+tags: "JavaScript"
+---
+
+Most functions run start to finish and hand back one value. **Generators**
+break that rule: they can pause in the middle, hand a value out, and later
+resume from the exact spot they stopped — locals and all. Understanding
+them explains `for...of`, the spread operator, lazy infinite sequences, and
+ultimately how `async/await` works.
+
+## The iterator protocol
+
+First, the contract everything is built on. An **iterator** is any object
+with a `next()` method that returns `{ value, done }`. An **iterable** is
+any object with a `[Symbol.iterator]` method that returns an iterator.
+`for...of`, spread (`...`), and destructuring all speak this protocol:
+
+```javascript
+const iter = [10, 20][Symbol.iterator]();
+iter.next(); // { value: 10, done: false }
+iter.next(); // { value: 20, done: false }
+iter.next(); // { value: undefined, done: true }
+```
+
+Arrays, strings, `Map`, and `Set` are all iterable — that's *why* you can
+spread or `for...of` them. You can make your own objects iterable by
+implementing `[Symbol.iterator]`, but writing a correct iterator by hand
+(tracking state across calls) is fiddly. Generators do it for you.
+
+## Generator functions
+
+A generator function — `function*` — returns an iterator, but its body
+doesn't run on call. Instead, each `yield` is a pause point. Calling
+`next()` runs the body up to the next `yield`, hands out that value, and
+freezes. The next `next()` thaws it and continues:
+
+<GeneratorVisualizer />
+
+```javascript
+function* counter() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+
+const g = counter();
+g.next(); // { value: 1, done: false }
+g.next(); // { value: 2, done: false }
+g.next(); // { value: 3, done: false }
+g.next(); // { value: undefined, done: true }
+```
+
+The revelation in the animation: calling `counter()` runs *nothing*. The
+body only advances when you pull the next value. Between pulls, the
+function sits frozen with its local state intact — that's the superpower
+plain functions don't have.
+
+Because a generator returns an iterator, it's automatically iterable:
+
+```javascript
+for (const n of counter()) console.log(n); // 1, 2, 3
+const nums = [...counter()];               // [1, 2, 3]
+```
+
+## Lazy and infinite sequences
+
+Since values are produced only on demand, a generator can describe an
+*infinite* sequence without looping forever — you just stop pulling:
+
+```javascript
+function* naturals() {
+  let n = 1;
+  while (true) yield n++;   // never terminates on its own
+}
+
+const g = naturals();
+g.next().value; // 1
+g.next().value; // 2   — computed only when asked
+```
+
+This laziness is the real value. You can express "all the natural numbers"
+or "every line of a huge file" as a generator and consume just the part you
+need, computing nothing extra. Pair it with a `take(gen, k)` helper and you
+have composable, memory-cheap pipelines.
+
+## Two-way communication
+
+`yield` is also an expression — whatever you pass to `next(value)` becomes
+the result of the paused `yield`. So data flows *in* as well as out:
+
+```javascript
+function* echo() {
+  const received = yield "ready";
+  yield `you said: ${received}`;
+}
+
+const g = echo();
+g.next();          // { value: "ready", done: false }
+g.next("hello");   // { value: "you said: hello", done: false }
+```
+
+This bidirectional channel is what makes generators powerful enough to
+drive async control flow.
+
+## The punchline: async/await is a generator
+
+Here's the connection that ties it together. An `async` function is
+essentially a generator where `await` plays the role of `yield` — it pauses
+the function until a promise settles, then resumes with the resolved value.
+Before `async/await` was a language feature, libraries like `co` implemented
+it *exactly* this way: a generator that yields promises, plus a runner that
+calls `next()` each time a promise resolves.
+
+```javascript
+// what async/await is doing, conceptually
+function run(genFn) {
+  const gen = genFn();
+  function step(value) {
+    const { value: promise, done } = gen.next(value);
+    if (done) return Promise.resolve(promise);
+    return Promise.resolve(promise).then(step); // resume when it settles
+  }
+  return step();
+}
+```
+
+The pause-and-resume machinery you watched in the animation is the same
+machinery that lets `await` suspend a function without blocking the thread.
+`async/await` is generators with promises wired in and the runner built
+into the engine.
+
+## Wrap-up
+
+Iterators are the `{ value, done }` protocol that `for...of` and spread rely
+on; generators are the easy way to produce them, with the unique ability to
+pause at `yield` and resume with state intact. That gives you lazy and even
+infinite sequences, two-way communication — and, once promises are mixed
+in, `async/await` itself.

--- a/src/app/blog/posts/javascript-prototypes-explained.mdx
+++ b/src/app/blog/posts/javascript-prototypes-explained.mdx
@@ -19,11 +19,27 @@ itself. If it's not there, it follows a hidden internal link — called
 `[[Prototype]]` — to another object and checks *that*, and so on up a
 chain until it either finds the property or reaches `null`.
 
-<PrototypeChainDiagram />
+Step through a real lookup below. We call `dog.eat()`, and the engine has
+to *find* `eat` by walking upward one link at a time — missing on the
+instance, missing on `Dog.prototype`, and finally hitting it on
+`Animal.prototype`:
+
+<PrototypeChainVisualizer />
 
 That's the entire mechanism. There is no copying, no "inherited members"
 baked into the object at creation — just a live pointer to another object
-and a lookup that walks it. You can see the link directly:
+and a lookup that walks it. Two things fall directly out of the animation
+and are worth naming:
+
+- **Lookup is dynamic, not cached at creation.** If you add `eat` to
+  `Animal.prototype` *after* `dog` already exists, the very next
+  `dog.eat()` finds it — the walk happens fresh on every access.
+- **The walk has a cost.** A property deep up the chain takes more hops
+  than an own property. It's rarely worth worrying about, but it's why a
+  hot loop reading a deeply-inherited getter can be measurably slower than
+  reading an own field.
+
+You can see the link directly:
 
 ```javascript
 const arr = [1, 2, 3];
@@ -121,6 +137,28 @@ new Dog().speak(); // "woof" — found on Dog.prototype first
 This is method overriding, and it falls out of the lookup rule for free —
 there's no special "override" machinery. `super.speak()` is how a child
 reaches past its own shadow to the parent's version.
+
+## instanceof is just a chain walk
+
+Once you picture the chain, `instanceof` stops being magic. `x instanceof C`
+asks a single question: *is `C.prototype` anywhere on `x`'s prototype
+chain?* It walks the same links the property lookup does, looking for one
+specific object instead of one specific key.
+
+```javascript
+class Animal {}
+class Dog extends Animal {}
+const rex = new Dog();
+
+rex instanceof Dog;    // true  — Dog.prototype is link #1
+rex instanceof Animal; // true  — Animal.prototype is link #2
+rex instanceof Object; // true  — Object.prototype is link #3
+```
+
+This is also why `instanceof` can *lie* across realms (e.g. an array from
+an `<iframe>` isn't `instanceof` the parent window's `Array`): different
+realm, different `Array.prototype`, so it's not on the chain. `Array.isArray`
+exists precisely to sidestep that.
 
 ## Where it bites
 

--- a/src/app/blog/posts/linked-lists-and-cycle-detection.mdx
+++ b/src/app/blog/posts/linked-lists-and-cycle-detection.mdx
@@ -1,0 +1,121 @@
+---
+title: "Linked Lists and Floyd's Cycle Detection"
+publishedAt: "2026-07-10"
+summary: "Why linked lists still matter, and the two-pointer trick that detects a loop in one pass with no extra memory — the famous tortoise and hare."
+tags: "DSA"
+---
+
+Arrays get all the attention, but the linked list is where a couple of the
+most elegant algorithms in the whole field live. Chief among them is
+**Floyd's cycle detection** — a way to tell whether a list loops back on
+itself using two pointers and no extra memory. It's worth learning both for
+the trick itself and for how it teaches you to think about pointers.
+
+## A quick refresher
+
+A linked list is a chain of nodes, each holding a value and a pointer to
+the next node. The last node points to `null`:
+
+```javascript
+class Node {
+  constructor(value) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+// 1 → 2 → 3 → null
+const head = new Node(1);
+head.next = new Node(2);
+head.next.next = new Node(3);
+```
+
+Unlike an array, there's no index — to reach the `k`-th node you follow
+`next` `k` times (`O(n)`). What you get in return is `O(1)` insertion and
+deletion once you're holding the right node: just rewire a couple of
+pointers, no shifting of elements.
+
+## The problem: is there a cycle?
+
+If some node's `next` points back to an earlier node, the list has a
+**cycle** — and a naive traversal loops forever. How do you detect that?
+
+The obvious approach stores every node you've seen in a `Set` and checks
+for a repeat: `O(n)` time but `O(n)` extra memory. Floyd's algorithm does
+it in `O(1)` memory.
+
+## The tortoise and the hare
+
+Run two pointers through the list at different speeds: **slow** moves one
+node per step, **fast** moves two. If the list ends (`null`), there's no
+cycle. But if there *is* a cycle, the fast pointer laps around and
+eventually lands on the slow one — they can't pass through each other
+without meeting:
+
+<LinkedListCycleVisualizer />
+
+```javascript
+function hasCycle(head) {
+  let slow = head, fast = head;
+
+  while (fast && fast.next) {
+    slow = slow.next;        // 1 step
+    fast = fast.next.next;   // 2 steps
+
+    if (slow === fast) return true; // they met → cycle
+  }
+  return false;              // fast hit null → no cycle
+}
+```
+
+### Why they're guaranteed to meet
+
+Once both pointers are inside the loop, think about the *gap* between them.
+Each step, fast gains one position on slow (it moves 2, slow moves 1, net
++1). The gap shrinks by exactly one every step, so it must eventually hit
+zero — a collision. It can never "jump over" slow, because closing a gap of
+1 lands them on the same node. That's the entire proof.
+
+## Bonus: where does the cycle start?
+
+Floyd's trick has a beautiful sequel. After the pointers meet, reset one to
+the head and move *both* one step at a time. They meet again exactly at the
+node where the cycle begins:
+
+```javascript
+function cycleStart(head) {
+  let slow = head, fast = head;
+  while (fast && fast.next) {
+    slow = slow.next;
+    fast = fast.next.next;
+    if (slow === fast) {          // phase 1: find a meeting point
+      let ptr = head;
+      while (ptr !== slow) {      // phase 2: walk to the entry
+        ptr = ptr.next;
+        slow = slow.next;
+      }
+      return ptr;                 // start of the cycle
+    }
+  }
+  return null;
+}
+```
+
+This falls out of the distance math: the gap from the head to the cycle
+entry equals the gap from the meeting point to the entry. You don't need to
+memorize the proof to use it, but it's a satisfying one to work through on
+paper.
+
+## Where this shows up
+
+- Detecting infinite loops in state machines or "next pointer" data
+- Finding duplicates in an array where values point to indices (the array
+  *is* a disguised linked list)
+- Any interview with the words "linked list" and "constant space"
+
+## Wrap-up
+
+Linked lists trade random access for cheap splicing, and they're the home
+of the tortoise-and-hare: two pointers at different speeds detect a cycle
+in one pass and `O(1)` memory. The gap-shrinks-by-one insight is the kind
+of reasoning that transfers far beyond this one problem.

--- a/src/app/blog/posts/recursion-and-the-call-stack.mdx
+++ b/src/app/blog/posts/recursion-and-the-call-stack.mdx
@@ -1,0 +1,123 @@
+---
+title: "Recursion and the Call Stack: What Actually Happens"
+publishedAt: "2026-07-08"
+summary: "Recursion feels like magic until you see the call stack. Here's the mechanical picture — frames pushing and popping — plus base cases, stack overflows, and tail calls."
+tags: "DSA"
+---
+
+Recursion trips people up because it asks you to trust a function that
+isn't finished yet. The trick to understanding it is to stop thinking about
+the *idea* of recursion and look at the *machine*: a stack of paused
+function calls, each waiting on the one above it.
+
+## Every call gets a frame
+
+When a function is called, the runtime pushes a **stack frame** — a little
+box holding that call's arguments, local variables, and where to return
+to. When the function returns, its frame pops off. Recursion is just a
+function that calls itself, so frames stack up until something stops the
+chain.
+
+Watch `factorial(3)` build up frames on the way down and resolve them on
+the way back up:
+
+<CallStackVisualizer />
+
+```javascript
+function factorial(n) {
+  if (n === 0) return 1;      // base case — stops the recursion
+  return n * factorial(n - 1); // recursive case — pauses, waits for the sub-call
+}
+```
+
+Notice the two phases. Going **down**, each call pauses at the
+multiplication because it can't finish until the inner call returns —
+frames pile up. Going **up**, the base case returns a concrete value and
+each paused frame completes its multiplication in reverse order. The answer
+is assembled during the unwinding.
+
+## The base case is not optional
+
+Every recursion needs a **base case** — an input it can answer without
+recursing — and every recursive call must move *toward* it. Forget either
+and the stack grows forever:
+
+```javascript
+function boom(n) {
+  return boom(n - 1); // no base case → frames forever
+}
+boom(5); // RangeError: Maximum call stack size exceeded
+```
+
+That error is the runtime telling you it ran out of room to push frames.
+Most engines cap the stack in the low tens of thousands of frames, so deep
+recursion on large inputs can overflow even when the logic is correct.
+
+## Recursion is a stack you didn't write
+
+Anything recursion does, you can do with an explicit stack — because that's
+literally what's happening under the hood. Here's depth-first traversal
+both ways:
+
+```javascript
+// Recursive: uses the call stack
+function walk(node) {
+  if (!node) return;
+  visit(node);
+  walk(node.left);
+  walk(node.right);
+}
+
+// Iterative: uses an explicit stack, no call frames
+function walkIterative(root) {
+  const stack = [root];
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node) continue;
+    visit(node);
+    stack.push(node.right, node.left); // left ends on top → visited first
+  }
+}
+```
+
+The iterative version can't overflow the call stack because the data lives
+on the heap instead. That's the standard escape hatch when recursion depth
+is a problem.
+
+## Tail calls (and why JavaScript mostly ignores them)
+
+A **tail call** is a recursive call that's the very last thing a function
+does — nothing waits on its result:
+
+```javascript
+function factorialTail(n, acc = 1) {
+  if (n === 0) return acc;
+  return factorialTail(n - 1, n * acc); // nothing left to do after this
+}
+```
+
+In principle the engine could reuse the current frame instead of pushing a
+new one, making this run in constant stack space (*tail-call
+optimization*). The ES2015 spec even requires it — but in practice almost
+no JavaScript engine implements it, so don't rely on it. If depth is a
+concern, convert to a loop.
+
+## Where recursion shines
+
+Recursion is the natural fit whenever the problem is **self-similar** — a
+thing defined in terms of smaller copies of itself:
+
+- Trees and graphs (each subtree is a tree)
+- Divide and conquer (merge sort, quick sort, binary search)
+- Backtracking (permutations, N-queens, parsing)
+
+For those, recursive code often reads almost exactly like the definition of
+the problem. For simple linear iteration, a plain loop is clearer and
+cheaper — don't recurse just to prove you can.
+
+## Wrap-up
+
+Recursion isn't magic; it's a stack of paused calls. Keep three things
+straight and it stops being scary: every call gets a frame, the base case
+is what lets the stack unwind, and deep recursion can overflow — at which
+point an explicit stack or a loop is your way out.

--- a/src/app/blog/posts/tries-prefix-trees.mdx
+++ b/src/app/blog/posts/tries-prefix-trees.mdx
@@ -1,0 +1,155 @@
+---
+title: "Tries: Searching by Prefix"
+publishedAt: "2026-07-11"
+summary: "The data structure behind autocomplete and spellcheck. How a trie stores words as shared character paths, and why lookups cost the length of the word — not the size of the dictionary."
+tags: "DSA"
+---
+
+Every time your phone finishes a word, or a search box suggests completions
+as you type, there's a good chance a **trie** (pronounced "try," from
+re*trie*val) is doing the work. It's a tree specialised for strings, and it
+turns "find every word starting with these letters" into a cheap, natural
+operation.
+
+## The idea: words as paths
+
+A trie stores a set of strings by their characters. Each edge is labelled
+with a letter, and each path from the root spells out a prefix. Words that
+share a prefix share the same path until they diverge — `cat`, `car`, and
+`card` all travel down `c → a` together before splitting:
+
+<TrieVisualizer />
+
+Two things to notice in the animation:
+
+- **Shared prefixes are stored once.** The `ca` path is a single sequence
+  of nodes no matter how many words use it. That's the space win.
+- **Nodes carry an "end of word" flag** (the double rings). The node for
+  `car` exists as part of the path to `card`, but whether `car` itself is a
+  stored word is a separate yes/no marker on the node.
+
+## Building one
+
+A trie node is just a map from a character to a child node, plus a boolean:
+
+```javascript
+class TrieNode {
+  constructor() {
+    this.children = new Map(); // char → TrieNode
+    this.isWord = false;
+  }
+}
+
+class Trie {
+  constructor() { this.root = new TrieNode(); }
+
+  insert(word) {
+    let node = this.root;
+    for (const ch of word) {
+      if (!node.children.has(ch)) {
+        node.children.set(ch, new TrieNode());
+      }
+      node = node.children.get(ch);   // descend, creating as needed
+    }
+    node.isWord = true;               // mark the final node
+  }
+}
+```
+
+Insertion walks the word one character at a time, creating child nodes when
+they don't exist yet, and flips `isWord` on the last node.
+
+## Searching and prefix matching
+
+Search follows the same path. The distinction between "is this a stored
+word" and "is this a prefix of some word" is just *which* flag you check at
+the end:
+
+```javascript
+  // exact word: path must exist AND the last node is a word end
+  search(word) {
+    const node = this.walk(word);
+    return node !== null && node.isWord;
+  }
+
+  // prefix: path must exist; end flag doesn't matter
+  startsWith(prefix) {
+    return this.walk(prefix) !== null;
+  }
+
+  // shared traversal helper
+  walk(str) {
+    let node = this.root;
+    for (const ch of str) {
+      if (!node.children.has(ch)) return null; // fell off the trie
+      node = node.children.get(ch);
+    }
+    return node;
+  }
+```
+
+The key property: a lookup takes **O(L)** time where `L` is the length of
+the query string — completely independent of how many words the trie
+holds. A million-word dictionary and a ten-word one search a 5-letter
+prefix in the same number of steps.
+
+## Autocomplete falls right out
+
+Once `startsWith` lands you on the node for a prefix, every word underneath
+it is a completion. Collect them with a small DFS:
+
+```javascript
+  autocomplete(prefix) {
+    const start = this.walk(prefix);
+    const results = [];
+    if (!start) return results;
+
+    const dfs = (node, path) => {
+      if (node.isWord) results.push(prefix + path);
+      for (const [ch, child] of node.children) {
+        dfs(child, path + ch);
+      }
+    };
+    dfs(start, "");
+    return results;
+  }
+```
+
+This is exactly the shape of a search-box suggestion list.
+
+## When a trie is (and isn't) the right call
+
+<table>
+  <thead>
+    <tr>
+      <th>Reach for a trie when…</th>
+      <th>Skip it when…</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>You need prefix queries / autocomplete</td>
+      <td>You only ever check exact membership</td>
+    </tr>
+    <tr>
+      <td>Many keys share long prefixes</td>
+      <td>Keys are random with little overlap</td>
+    </tr>
+    <tr>
+      <td>You want keys in sorted order for free</td>
+      <td>Memory is tight (a hash set is leaner)</td>
+    </tr>
+  </tbody>
+</table>
+
+For pure exact-match lookups, a hash set is simpler and usually smaller — a
+trie earns its keep when *prefixes* are the point. The main cost is memory:
+each node carries a map of children, which adds up.
+
+## Wrap-up
+
+A trie stores strings as a tree of shared character paths, so lookups cost
+the length of the word rather than the size of the dictionary, and every
+prefix query — the hard part in other structures — becomes a simple walk to
+a node followed by a traversal of what's below it. That's autocomplete,
+spellcheck, and IP routing tables, all from one idea.

--- a/src/app/blog/posts/two-pointers-and-sliding-window.mdx
+++ b/src/app/blog/posts/two-pointers-and-sliding-window.mdx
@@ -1,0 +1,147 @@
+---
+title: "Two Pointers and the Sliding Window"
+publishedAt: "2026-07-08"
+summary: "Two of the highest-leverage array patterns in interviews and real code — how they turn nested O(n²) loops into a single O(n) pass, and when each one applies."
+tags: "DSA"
+---
+
+A huge fraction of array and string problems that *look* like they need
+nested loops actually don't. Two related patterns — **two pointers** and
+the **sliding window** — collapse that quadratic work into a single pass by
+never throwing away information you already computed. Once you recognize
+the shape, you'll see them everywhere.
+
+## The problem with the naive approach
+
+Say you want the maximum sum of any 3 consecutive elements in an array. The
+obvious solution sums every window from scratch:
+
+```javascript
+function maxSum(arr, k) {
+  let best = -Infinity;
+  for (let i = 0; i + k <= arr.length; i++) {
+    let sum = 0;
+    for (let j = i; j < i + k; j++) sum += arr[j]; // re-adds k elements
+    best = Math.max(best, sum);
+  }
+  return best;
+}
+```
+
+That inner loop re-adds `k` numbers for every position — `O(n·k)` work. But
+look at what happens when the window moves one step right: it loses its
+leftmost element and gains one on the right. Everything in the middle is
+*identical*. We're recomputing what we already knew.
+
+## The sliding window
+
+Keep a running sum. When the window slides, subtract the element leaving
+and add the one entering — two operations, regardless of window size:
+
+<SlidingWindowVisualizer />
+
+```javascript
+function maxSum(arr, k) {
+  let sum = 0;
+  for (let i = 0; i < k; i++) sum += arr[i]; // first window
+  let best = sum;
+
+  for (let end = k; end < arr.length; end++) {
+    sum += arr[end] - arr[end - k]; // add new, drop old
+    best = Math.max(best, sum);
+  }
+  return best;
+}
+```
+
+One pass, `O(n)` time, `O(1)` space. The window carries its state forward
+instead of rebuilding it.
+
+### Fixed vs. dynamic windows
+
+The example above is a **fixed-size** window. The more powerful variant is
+the **dynamic window**, where the right edge expands to include more and
+the left edge contracts when a constraint breaks. The classic is *longest
+substring without repeating characters*:
+
+```javascript
+function longestUnique(s) {
+  const seen = new Set();
+  let left = 0, best = 0;
+
+  for (let right = 0; right < s.length; right++) {
+    while (seen.has(s[right])) {
+      seen.delete(s[left]); // shrink from the left until valid again
+      left++;
+    }
+    seen.add(s[right]);
+    best = Math.max(best, right - left + 1);
+  }
+  return best;
+}
+```
+
+Each character is added once and removed at most once, so even with the
+inner `while` this is still `O(n)` — the pointers only ever move forward.
+
+## Two pointers
+
+The sliding window is really a special case of the broader **two pointers**
+idea: maintain two indices and move them based on the data instead of
+brute-forcing every pair. The other common flavor is **converging
+pointers** on a sorted array — one from each end, walking toward the
+middle. Finding a pair that sums to a target:
+
+```javascript
+function twoSumSorted(arr, target) {
+  let lo = 0, hi = arr.length - 1;
+  while (lo < hi) {
+    const sum = arr[lo] + arr[hi];
+    if (sum === target) return [lo, hi];
+    if (sum < target) lo++;  // need more → move the low end up
+    else hi--;               // need less → move the high end down
+  }
+  return null;
+}
+```
+
+Because the array is sorted, each comparison lets us *rule out* an entire
+row or column of the pair space — `O(n)` instead of the `O(n²)` of checking
+all pairs.
+
+## How to spot them
+
+<table>
+  <thead>
+    <tr>
+      <th>Signal in the problem</th>
+      <th>Reach for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>"subarray / substring of size k" or "contiguous"</td>
+      <td>Sliding window</td>
+    </tr>
+    <tr>
+      <td>"longest / shortest window satisfying a condition"</td>
+      <td>Dynamic sliding window</td>
+    </tr>
+    <tr>
+      <td>Sorted array, find a pair / triplet</td>
+      <td>Converging two pointers</td>
+    </tr>
+    <tr>
+      <td>In-place partition, dedupe, or reverse</td>
+      <td>Two pointers (read + write)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Wrap-up
+
+The common thread is **don't recompute what hasn't changed**. A sliding
+window updates its state incrementally as it moves; two converging pointers
+use sorted order to discard half the possibilities each step. Both trade a
+nested loop for a single forward sweep — the difference between code that
+scales and code that times out.

--- a/src/app/components/bit-visualizer.tsx
+++ b/src/app/components/bit-visualizer.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+type Step = {
+  value: number
+  cleared?: number // bit index (0 = LSB) cleared this step
+  count: number
+  done?: boolean
+  note: string
+}
+
+// Brian Kernighan's bit count on 22 = 0b00010110.
+const steps: Step[] = [
+  { value: 22, count: 0, note: 'Count the set bits in 22 = 00010110. The trick: n & (n − 1) always clears the lowest set bit.' },
+  { value: 20, cleared: 1, count: 1, note: '22 & 21 clears bit 1. n becomes 00010100, count = 1. We skipped straight over the zero bits.' },
+  { value: 16, cleared: 2, count: 2, note: '20 & 19 clears bit 2. n becomes 00010000, count = 2.' },
+  { value: 0, cleared: 4, count: 3, note: '16 & 15 clears bit 4. n becomes 00000000, count = 3.' },
+  { value: 0, count: 3, done: true, note: 'n is 0, so we stop. The loop ran exactly 3 times — once per set bit — not 8. That is O(set bits), not O(bit width).' },
+]
+
+function bits(value: number) {
+  return Array.from({ length: 8 }, (_, i) => (value >> (7 - i)) & 1)
+}
+
+export function BitVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        const row = bits(step.value)
+        return (
+          <>
+            <div className="flex justify-center gap-1.5">
+              {row.map((bit, i) => {
+                const bitIndex = 7 - i
+                const isCleared = step.cleared === bitIndex
+                return (
+                  <div key={i} className="flex flex-col items-center gap-1">
+                    <div
+                      className={[
+                        'flex h-11 w-9 items-center justify-center rounded-md font-mono text-sm transition-all duration-300',
+                        isCleared
+                          ? 'bg-amber-500 text-white line-through'
+                          : bit
+                            ? 'bg-green-600 text-white dark:bg-green-500'
+                            : 'bg-neutral-100 text-neutral-400 dark:bg-neutral-800 dark:text-neutral-600',
+                      ].join(' ')}
+                    >
+                      {bit}
+                    </div>
+                    <span className="font-mono text-[10px] text-neutral-400 tabular-nums dark:text-neutral-500">
+                      {bitIndex}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="mt-3 flex justify-center gap-6 font-mono text-xs text-neutral-600 dark:text-neutral-300">
+              <span>
+                n = <span className="tabular-nums">{step.value}</span>
+              </span>
+              <span>
+                count ={' '}
+                <span className="text-green-600 tabular-nums dark:text-green-500">
+                  {step.count}
+                </span>
+              </span>
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/call-stack-visualizer.tsx
+++ b/src/app/components/call-stack-visualizer.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+type Frame = { label: string; returning?: boolean }
+
+type Step = {
+  frames: Frame[]
+  note: string
+}
+
+// Tracing factorial(3): frames push on the way down, pop (resolve) on the way up.
+const steps: Step[] = [
+  { frames: [{ label: 'factorial(3)' }], note: 'Call factorial(3). It needs 3 × factorial(2), so it pauses and pushes a new frame.' },
+  { frames: [{ label: 'factorial(3)' }, { label: 'factorial(2)' }], note: 'factorial(2) needs 2 × factorial(1) — another frame pushed on top. The stack grows downward.' },
+  { frames: [{ label: 'factorial(3)' }, { label: 'factorial(2)' }, { label: 'factorial(1)' }], note: 'factorial(1) needs 1 × factorial(0). One more frame.' },
+  { frames: [{ label: 'factorial(3)' }, { label: 'factorial(2)' }, { label: 'factorial(1)' }, { label: 'factorial(0)' }], note: 'factorial(0) hits the base case and returns 1 immediately — no more recursion. Now the stack unwinds.' },
+  { frames: [{ label: 'factorial(3)' }, { label: 'factorial(2)' }, { label: 'factorial(1) → 1', returning: true }], note: 'factorial(0) returned 1, so factorial(1) computes 1 × 1 = 1 and returns. Its frame pops.' },
+  { frames: [{ label: 'factorial(3)' }, { label: 'factorial(2) → 2', returning: true }], note: 'factorial(1) returned 1, so factorial(2) computes 2 × 1 = 2 and returns.' },
+  { frames: [{ label: 'factorial(3) → 6', returning: true }], note: 'factorial(2) returned 2, so factorial(3) computes 3 × 2 = 6 and returns. The stack is empty again.' },
+]
+
+export function CallStackVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <div className="mx-auto flex min-h-[220px] max-w-xs flex-col-reverse justify-start gap-1.5">
+              {step.frames.map((frame, i) => (
+                <div
+                  key={i}
+                  className={[
+                    'rounded-md border px-3 py-2 text-center font-mono text-xs transition-all duration-300',
+                    frame.returning
+                      ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
+                      : i === step.frames.length - 1
+                        ? 'border-amber-500 bg-amber-500 text-white'
+                        : 'border-neutral-200 bg-neutral-100 text-neutral-600 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
+                  ].join(' ')}
+                >
+                  {frame.label}
+                </div>
+              ))}
+              <div className="mt-1 text-center font-mono text-[10px] text-neutral-400 dark:text-neutral-500">
+                ↑ top of stack
+              </div>
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/consistent-hash-ring-visualizer.tsx
+++ b/src/app/components/consistent-hash-ring-visualizer.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+const CX = 150
+const CY = 150
+const R = 108
+
+function xy(angleDeg: number, radius = R) {
+  const rad = (angleDeg * Math.PI) / 180
+  return { x: CX + radius * Math.sin(rad), y: CY - radius * Math.cos(rad) }
+}
+
+const SERVER_ANGLE: Record<string, number> = { A: 20, B: 140, C: 250, D: 320 }
+const KEY_ANGLE: Record<string, number> = { k1: 60, k2: 100, k3: 200, k4: 300, k5: 10 }
+
+const NODE_FILL: Record<string, string> = {
+  A: 'fill-green-600 dark:fill-green-500',
+  B: 'fill-sky-500',
+  C: 'fill-amber-500',
+  D: 'fill-violet-500',
+}
+
+type Step = {
+  servers: string[]
+  assign: Record<string, string | null>
+  moved: string[]
+  note: string
+}
+
+const base = { k1: 'B', k2: 'B', k3: 'C', k4: 'A', k5: 'A' }
+
+const steps: Step[] = [
+  {
+    servers: ['A', 'B', 'C'],
+    assign: { k1: null, k2: null, k3: null, k4: null, k5: null },
+    moved: [],
+    note: 'Servers and keys are both hashed onto one ring. Three servers A, B, C are placed. Five keys sit at their own hashed positions.',
+  },
+  {
+    servers: ['A', 'B', 'C'],
+    assign: base,
+    moved: [],
+    note: 'Each key belongs to the first server found walking clockwise. k1, k2 → B; k3 → C; k4, k5 → A (wrapping past the top).',
+  },
+  {
+    servers: ['A', 'B', 'C', 'D'],
+    assign: { ...base, k4: 'D' },
+    moved: ['k4'],
+    note: 'Add server D. Only keys in the arc just before D are affected — that is only k4, which moves from A to D. Everything else stays put.',
+  },
+  {
+    servers: ['A', 'B', 'C', 'D'],
+    assign: { ...base, k4: 'D' },
+    moved: ['k4'],
+    note: 'Just 1 of 5 keys remapped. A naive hash % N would have reshuffled almost all of them. That stability is why consistent hashing runs behind caches, shards, and CDNs.',
+  },
+]
+
+export function ConsistentHashRingVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1800}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <svg
+              viewBox="0 0 300 300"
+              className="mx-auto block w-full max-w-xs"
+              role="img"
+              aria-label="Consistent hashing ring with servers and keys"
+            >
+              <circle
+                cx={CX}
+                cy={CY}
+                r={R}
+                fill="none"
+                className="stroke-neutral-200 dark:stroke-neutral-700"
+                strokeWidth={1.5}
+              />
+              {/* keys */}
+              {Object.keys(KEY_ANGLE).map((k) => {
+                const p = xy(KEY_ANGLE[k], R)
+                const server = step.assign[k]
+                const isMoved = step.moved.includes(k)
+                return (
+                  <g key={k}>
+                    <circle
+                      cx={p.x}
+                      cy={p.y}
+                      r={isMoved ? 8 : 6}
+                      className={
+                        server
+                          ? NODE_FILL[server]
+                          : 'fill-neutral-300 dark:fill-neutral-600'
+                      }
+                      stroke={isMoved ? '#f59e0b' : 'none'}
+                      strokeWidth={isMoved ? 2 : 0}
+                    />
+                    <text
+                      x={xy(KEY_ANGLE[k], R + 18).x}
+                      y={xy(KEY_ANGLE[k], R + 18).y + 3}
+                      textAnchor="middle"
+                      className="fill-neutral-400 font-mono text-[9px] dark:fill-neutral-500"
+                    >
+                      {k}
+                    </text>
+                  </g>
+                )
+              })}
+              {/* servers */}
+              {step.servers.map((s) => {
+                const p = xy(SERVER_ANGLE[s], R)
+                return (
+                  <g key={s}>
+                    <rect
+                      x={p.x - 12}
+                      y={p.y - 12}
+                      width={24}
+                      height={24}
+                      rx={5}
+                      className={NODE_FILL[s]}
+                    />
+                    <text
+                      x={p.x}
+                      y={p.y + 4}
+                      textAnchor="middle"
+                      className="fill-white font-mono text-[12px]"
+                    >
+                      {s}
+                    </text>
+                  </g>
+                )
+              })}
+            </svg>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/dp-table-visualizer.tsx
+++ b/src/app/components/dp-table-visualizer.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+const N = 7
+
+type Step = {
+  filled: number // how many cells are computed (indices 0..filled-1)
+  current?: number // the cell just written
+  sources?: [number, number] // the two cells summed
+  note: string
+}
+
+// Climbing stairs: ways[i] = ways[i-1] + ways[i-2], ways[0]=ways[1]=1.
+const VALUES = [1, 1, 2, 3, 5, 8, 13, 21] // ways[0..7]
+
+const steps: Step[] = [
+  { filled: 2, current: 1, note: 'Base cases: there is 1 way to stand at step 0, and 1 way to reach step 1. Fill those in first.' },
+  { filled: 3, current: 2, sources: [0, 1], note: 'ways[2] = ways[1] + ways[0] = 1 + 1 = 2. Each cell reuses two answers we already have.' },
+  { filled: 4, current: 3, sources: [1, 2], note: 'ways[3] = ways[2] + ways[1] = 2 + 1 = 3.' },
+  { filled: 5, current: 4, sources: [2, 3], note: 'ways[4] = ways[3] + ways[2] = 3 + 2 = 5.' },
+  { filled: 6, current: 5, sources: [3, 4], note: 'ways[5] = ways[4] + ways[3] = 5 + 3 = 8.' },
+  { filled: 7, current: 6, sources: [4, 5], note: 'ways[6] = ways[5] + ways[4] = 8 + 5 = 13.' },
+  { filled: 8, current: 7, sources: [5, 6], note: 'ways[7] = ways[6] + ways[5] = 13 + 8 = 21. One left-to-right pass, no recomputation — this is tabulation.' },
+]
+
+export function DPTableVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1500}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <div className="flex flex-wrap justify-center gap-1.5">
+              {Array.from({ length: N + 1 }).map((_, i) => {
+                const isFilled = i < step.filled
+                const isCurrent = step.current === i
+                const isSource =
+                  step.sources?.includes(i) && !isCurrent
+                return (
+                  <div key={i} className="flex flex-col items-center gap-1">
+                    <div
+                      className={[
+                        'flex h-11 w-11 items-center justify-center rounded-md font-mono text-sm transition-all duration-300',
+                        isCurrent
+                          ? 'bg-amber-500 text-white'
+                          : isSource
+                            ? 'bg-green-600 text-white dark:bg-green-500'
+                            : isFilled
+                              ? 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300'
+                              : 'border border-dashed border-neutral-200 text-neutral-300 dark:border-neutral-700 dark:text-neutral-700',
+                      ].join(' ')}
+                    >
+                      {isFilled ? VALUES[i] : '·'}
+                    </div>
+                    <span className="font-mono text-[10px] text-neutral-400 tabular-nums dark:text-neutral-500">
+                      {i}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/generator-visualizer.tsx
+++ b/src/app/components/generator-visualizer.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+const LINES = [
+  'function* counter() {',
+  '  yield 1',
+  '  yield 2',
+  '  yield 3',
+  '}',
+]
+
+type Step = {
+  line: number // paused/active line index, -1 = not started
+  log: string[]
+  note: string
+}
+
+const steps: Step[] = [
+  { line: -1, log: [], note: 'const g = counter() — calling a generator runs NO code. It hands back a paused iterator. Generators are lazy.' },
+  { line: 1, log: ['g.next() → { value: 1, done: false }'], note: 'First g.next() runs until the first yield, hands back 1, and freezes right there — local state and all.' },
+  { line: 2, log: ['g.next() → { value: 1, done: false }', 'g.next() → { value: 2, done: false }'], note: 'Next g.next() resumes exactly where it paused, runs to the second yield, returns 2, and freezes again.' },
+  { line: 3, log: ['g.next() → { value: 1, done: false }', 'g.next() → { value: 2, done: false }', 'g.next() → { value: 3, done: false }'], note: 'Again: resume, run to yield 3, return 3, pause. The function body is being driven one slice at a time.' },
+  { line: 4, log: ['g.next() → { value: 1, done: false }', 'g.next() → { value: 2, done: false }', 'g.next() → { value: 3, done: false }', 'g.next() → { value: undefined, done: true }'], note: 'A final g.next() runs off the end. No more yields, so value is undefined and done is true. This pause/resume machinery is exactly what async/await is built on.' },
+]
+
+export function GeneratorVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1800}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-lg bg-neutral-50 p-3 dark:bg-neutral-900">
+                {LINES.map((line, i) => {
+                  const isActive = step.line === i
+                  return (
+                    <div
+                      key={i}
+                      className={[
+                        'rounded px-2 py-0.5 font-mono text-xs transition-colors duration-200',
+                        isActive
+                          ? 'bg-amber-500 text-white'
+                          : 'text-neutral-600 dark:text-neutral-300',
+                      ].join(' ')}
+                    >
+                      {line}
+                      {isActive && i >= 1 && i <= 3 ? '  ⏸' : ''}
+                    </div>
+                  )
+                })}
+              </div>
+              <div className="rounded-lg bg-neutral-50 p-3 dark:bg-neutral-900">
+                <div className="mb-1 font-mono text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
+                  output
+                </div>
+                {step.log.length === 0 ? (
+                  <div className="font-mono text-xs text-neutral-300 dark:text-neutral-600">
+                    (nothing yet)
+                  </div>
+                ) : (
+                  step.log.map((line, i) => (
+                    <div
+                      key={i}
+                      className={[
+                        'font-mono text-[11px]',
+                        i === step.log.length - 1
+                          ? 'text-green-600 dark:text-green-500'
+                          : 'text-neutral-500 dark:text-neutral-400',
+                      ].join(' ')}
+                    >
+                      {line}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/graph-traversal-visualizer.tsx
+++ b/src/app/components/graph-traversal-visualizer.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+type GNode = { id: string; x: number; y: number }
+
+const NODES: GNode[] = [
+  { id: 'A', x: 150, y: 30 },
+  { id: 'B', x: 80, y: 105 },
+  { id: 'C', x: 220, y: 105 },
+  { id: 'D', x: 40, y: 180 },
+  { id: 'E', x: 120, y: 180 },
+  { id: 'F', x: 260, y: 180 },
+]
+
+const EDGES: [string, string][] = [
+  ['A', 'B'],
+  ['A', 'C'],
+  ['B', 'D'],
+  ['B', 'E'],
+  ['C', 'F'],
+]
+
+const POS = new Map(NODES.map((n) => [n.id, n]))
+
+type Step = {
+  visited: string[]
+  current?: string
+  frontier: string[]
+  frontierLabel: string
+  note: string
+}
+
+function GraphView({ step }: { step: Step }) {
+  return (
+    <>
+      <svg
+        viewBox="0 0 300 210"
+        className="mx-auto block w-full max-w-sm"
+        role="img"
+        aria-label="Graph traversal diagram"
+      >
+        {EDGES.map(([a, b], i) => {
+          const pa = POS.get(a)!
+          const pb = POS.get(b)!
+          return (
+            <line
+              key={i}
+              x1={pa.x}
+              y1={pa.y}
+              x2={pb.x}
+              y2={pb.y}
+              className="stroke-neutral-200 dark:stroke-neutral-700"
+              strokeWidth={1.5}
+            />
+          )
+        })}
+        {NODES.map((n) => {
+          const isCurrent = step.current === n.id
+          const isVisited = step.visited.includes(n.id)
+          const inFrontier = step.frontier.includes(n.id)
+          return (
+            <g key={n.id}>
+              <circle
+                cx={n.x}
+                cy={n.y}
+                r={16}
+                className={
+                  isCurrent
+                    ? 'fill-amber-500'
+                    : isVisited
+                      ? 'fill-green-600 dark:fill-green-500'
+                      : inFrontier
+                        ? 'fill-neutral-300 dark:fill-neutral-600'
+                        : 'fill-neutral-100 dark:fill-neutral-800'
+                }
+              />
+              <text
+                x={n.x}
+                y={n.y + 4}
+                textAnchor="middle"
+                className={[
+                  'font-mono text-[12px]',
+                  isCurrent || isVisited
+                    ? 'fill-white'
+                    : 'fill-neutral-700 dark:fill-neutral-300',
+                ].join(' ')}
+              >
+                {n.id}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+      <div className="mt-2 text-center font-mono text-xs text-neutral-600 dark:text-neutral-300">
+        {step.frontierLabel}:{' '}
+        <span className="text-amber-500">[{step.frontier.join(', ')}]</span>
+      </div>
+      <StepNote>{step.note}</StepNote>
+    </>
+  )
+}
+
+const bfsSteps: Step[] = [
+  { visited: [], frontier: ['A'], frontierLabel: 'queue', note: 'BFS uses a queue (FIFO). Start by enqueueing A.' },
+  { visited: ['A'], current: 'A', frontier: ['B', 'C'], frontierLabel: 'queue', note: 'Dequeue A, mark it visited, enqueue its neighbours B and C.' },
+  { visited: ['A', 'B'], current: 'B', frontier: ['C', 'D', 'E'], frontierLabel: 'queue', note: 'Dequeue B (it went in first). Enqueue its unvisited neighbours D and E behind C.' },
+  { visited: ['A', 'B', 'C'], current: 'C', frontier: ['D', 'E', 'F'], frontierLabel: 'queue', note: 'Dequeue C. Enqueue F. Notice we finish the whole first level before going deeper.' },
+  { visited: ['A', 'B', 'C', 'D'], current: 'D', frontier: ['E', 'F'], frontierLabel: 'queue', note: 'Dequeue D — a leaf, no new neighbours.' },
+  { visited: ['A', 'B', 'C', 'D', 'E'], current: 'E', frontier: ['F'], frontierLabel: 'queue', note: 'Dequeue E — also a leaf.' },
+  { visited: ['A', 'B', 'C', 'D', 'E', 'F'], current: 'F', frontier: [], frontierLabel: 'queue', note: 'Dequeue F. Queue empty — done. Visit order A B C D E F is level by level, which is why BFS finds shortest paths in unweighted graphs.' },
+]
+
+const dfsSteps: Step[] = [
+  { visited: [], frontier: ['A'], frontierLabel: 'stack', note: 'DFS uses a stack (LIFO) — or the call stack via recursion. Push A.' },
+  { visited: ['A'], current: 'A', frontier: ['C', 'B'], frontierLabel: 'stack', note: 'Pop A, mark visited, push neighbours. B ends up on top, so we will dive into B first.' },
+  { visited: ['A', 'B'], current: 'B', frontier: ['C', 'E', 'D'], frontierLabel: 'stack', note: 'Pop B. Push D and E. We go deep, not wide — B before we ever touch C.' },
+  { visited: ['A', 'B', 'D'], current: 'D', frontier: ['C', 'E'], frontierLabel: 'stack', note: 'Pop D — a leaf. Backtrack.' },
+  { visited: ['A', 'B', 'D', 'E'], current: 'E', frontier: ['C'], frontierLabel: 'stack', note: 'Pop E — a leaf. B’s subtree is fully explored; only now do we return to C.' },
+  { visited: ['A', 'B', 'D', 'E', 'C'], current: 'C', frontier: ['F'], frontierLabel: 'stack', note: 'Pop C. Push F.' },
+  { visited: ['A', 'B', 'D', 'E', 'C', 'F'], current: 'F', frontier: [], frontierLabel: 'stack', note: 'Pop F. Done. Visit order A B D E C F dives to the bottom of each branch before backtracking.' },
+]
+
+export function GraphBFSVisualizer() {
+  return (
+    <StepPlayer length={bfsSteps.length} interval={1600}>
+      {(index) => <GraphView step={bfsSteps[index]} />}
+    </StepPlayer>
+  )
+}
+
+export function GraphDFSVisualizer() {
+  return (
+    <StepPlayer length={dfsSteps.length} interval={1600}>
+      {(index) => <GraphView step={dfsSteps[index]} />}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/heap-visualizer.tsx
+++ b/src/app/components/heap-visualizer.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+const POS = [
+  { x: 150, y: 28 }, // 0
+  { x: 85, y: 92 }, // 1
+  { x: 215, y: 92 }, // 2
+  { x: 50, y: 156 }, // 3
+  { x: 120, y: 156 }, // 4
+  { x: 185, y: 156 }, // 5
+  { x: 250, y: 156 }, // 6
+]
+
+const EDGES: [number, number][] = [
+  [0, 1],
+  [0, 2],
+  [1, 3],
+  [1, 4],
+  [2, 5],
+  [2, 6],
+]
+
+type Step = {
+  heap: number[]
+  active?: number
+  parent?: number
+  done?: boolean
+  note: string
+}
+
+// Min-heap. Insert 0 into [1,3,2,7,5,4] and sift it up.
+const steps: Step[] = [
+  { heap: [1, 3, 2, 7, 5, 4], note: 'A min-heap: every parent is ≤ its children, so the smallest value is always at the root. We insert 0.' },
+  { heap: [1, 3, 2, 7, 5, 4, 0], active: 6, parent: 2, note: 'New values go at the next open slot (index 6) to keep the tree complete. But 0 < its parent 2 — the heap property is broken.' },
+  { heap: [1, 3, 0, 7, 5, 4, 2], active: 2, parent: 0, note: 'Swap 0 up with its parent. Now compare 0 with the new parent, the root 1. Still smaller.' },
+  { heap: [0, 3, 1, 7, 5, 4, 2], active: 0, done: true, note: 'Swap again — 0 is now the root. It has no parent, so we stop. Insertion is O(log n): at most one swap per level.' },
+]
+
+export function HeapVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        const n = step.heap.length
+        return (
+          <>
+            <svg
+              viewBox="0 0 300 185"
+              className="mx-auto block w-full max-w-sm"
+              role="img"
+              aria-label="Min-heap represented as a binary tree during an insert"
+            >
+              {EDGES.filter(([a, b]) => a < n && b < n).map(([a, b], i) => (
+                <line
+                  key={i}
+                  x1={POS[a].x}
+                  y1={POS[a].y}
+                  x2={POS[b].x}
+                  y2={POS[b].y}
+                  className="stroke-neutral-200 dark:stroke-neutral-700"
+                  strokeWidth={1.5}
+                />
+              ))}
+              {step.heap.map((v, i) => {
+                const isActive = step.active === i
+                const isParent = step.parent === i
+                const isDone = isActive && step.done
+                return (
+                  <g key={i}>
+                    <circle
+                      cx={POS[i].x}
+                      cy={POS[i].y}
+                      r={16}
+                      className={
+                        isDone
+                          ? 'fill-green-600 dark:fill-green-500'
+                          : isActive
+                            ? 'fill-amber-500'
+                            : isParent
+                              ? 'fill-sky-500'
+                              : 'fill-neutral-100 dark:fill-neutral-800'
+                      }
+                    />
+                    <text
+                      x={POS[i].x}
+                      y={POS[i].y + 4}
+                      textAnchor="middle"
+                      className={[
+                        'font-mono text-[12px]',
+                        isActive || isParent || isDone
+                          ? 'fill-white'
+                          : 'fill-neutral-700 dark:fill-neutral-300',
+                      ].join(' ')}
+                    >
+                      {v}
+                    </text>
+                  </g>
+                )
+              })}
+            </svg>
+            <div className="mt-2 text-center font-mono text-xs text-neutral-500 dark:text-neutral-400">
+              array: [{step.heap.join(', ')}]
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/linked-list-cycle-visualizer.tsx
+++ b/src/app/components/linked-list-cycle-visualizer.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+// Nodes 0..5 in a row; node 5 links back to node 2, forming a cycle.
+const XS = [30, 90, 150, 210, 270, 330]
+const Y = 60
+
+type Step = {
+  slow: number
+  fast: number
+  met?: boolean
+  note: string
+}
+
+const steps: Step[] = [
+  { slow: 0, fast: 0, note: 'Two pointers start at the head. The tortoise moves 1 step at a time, the hare moves 2. The list has a hidden cycle (5 → 2).' },
+  { slow: 1, fast: 2, note: 'Tortoise → 1, hare → 2. The gap between them grows by one each round.' },
+  { slow: 2, fast: 4, note: 'Tortoise → 2, hare → 4. The hare is about to enter the cycle from the far end.' },
+  { slow: 3, fast: 2, note: 'Tortoise → 3. Hare goes 4 → 5 → 2, wrapping around the cycle. Now both are inside the loop.' },
+  { slow: 4, fast: 4, met: true, note: 'Tortoise → 4. Hare goes 2 → 3 → 4. They collide! A meeting is proof the list has a cycle — O(n) time, O(1) space.' },
+]
+
+export function LinkedListCycleVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <svg
+              viewBox="0 0 360 150"
+              className="mx-auto block w-full max-w-md"
+              role="img"
+              aria-label="Linked list with a cycle, traversed by slow and fast pointers"
+            >
+              {/* forward arrows */}
+              {XS.slice(0, -1).map((x, i) => (
+                <line
+                  key={i}
+                  x1={x + 16}
+                  y1={Y}
+                  x2={XS[i + 1] - 16}
+                  y2={Y}
+                  className="stroke-neutral-300 dark:stroke-neutral-600"
+                  strokeWidth={1.5}
+                />
+              ))}
+              {/* back edge 5 -> 2 */}
+              <path
+                d={`M ${XS[5]} ${Y + 16} C ${XS[5]} ${Y + 70}, ${XS[2]} ${Y + 70}, ${XS[2]} ${Y + 16}`}
+                fill="none"
+                className="stroke-neutral-300 dark:stroke-neutral-600"
+                strokeWidth={1.5}
+                strokeDasharray="4 3"
+              />
+              {XS.map((x, i) => {
+                const isSlow = step.slow === i
+                const isFast = step.fast === i
+                const both = isSlow && isFast
+                return (
+                  <g key={i}>
+                    <circle
+                      cx={x}
+                      cy={Y}
+                      r={16}
+                      className={
+                        both && step.met
+                          ? 'fill-green-600 dark:fill-green-500'
+                          : isSlow
+                            ? 'fill-sky-500'
+                            : isFast
+                              ? 'fill-amber-500'
+                              : 'fill-neutral-100 dark:fill-neutral-800'
+                      }
+                    />
+                    <text
+                      x={x}
+                      y={Y + 4}
+                      textAnchor="middle"
+                      className={[
+                        'font-mono text-[11px]',
+                        isSlow || isFast
+                          ? 'fill-white'
+                          : 'fill-neutral-600 dark:fill-neutral-300',
+                      ].join(' ')}
+                    >
+                      {i}
+                    </text>
+                    {isSlow && (
+                      <text x={x} y={Y - 24} textAnchor="middle" className="fill-sky-500 font-mono text-[10px]">
+                        slow
+                      </text>
+                    )}
+                    {isFast && (
+                      <text x={x} y={both ? Y - 38 : Y - 24} textAnchor="middle" className="fill-amber-500 font-mono text-[10px]">
+                        fast
+                      </text>
+                    )}
+                  </g>
+                )
+              })}
+            </svg>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/mdx.tsx
+++ b/src/app/components/mdx.tsx
@@ -19,6 +19,20 @@ import {
   PrototypeChainDiagram,
   ScopeChainDiagram,
 } from '@/app/components/diagrams'
+import { PrototypeChainVisualizer } from '@/app/components/prototype-chain-visualizer'
+import { SlidingWindowVisualizer } from '@/app/components/sliding-window-visualizer'
+import { CallStackVisualizer } from '@/app/components/call-stack-visualizer'
+import {
+  GraphBFSVisualizer,
+  GraphDFSVisualizer,
+} from '@/app/components/graph-traversal-visualizer'
+import { DPTableVisualizer } from '@/app/components/dp-table-visualizer'
+import { LinkedListCycleVisualizer } from '@/app/components/linked-list-cycle-visualizer'
+import { HeapVisualizer } from '@/app/components/heap-visualizer'
+import { TrieVisualizer } from '@/app/components/trie-visualizer'
+import { BitVisualizer } from '@/app/components/bit-visualizer'
+import { ConsistentHashRingVisualizer } from '@/app/components/consistent-hash-ring-visualizer'
+import { GeneratorVisualizer } from '@/app/components/generator-visualizer'
 import { CopyButton } from '@/app/components/copy-button'
 
 function Table({ data }: { data: { headers: string[]; rows: string[][] } }) {
@@ -149,6 +163,18 @@ const components = {
   PromiseStateDiagram,
   PrototypeChainDiagram,
   ScopeChainDiagram,
+  PrototypeChainVisualizer,
+  SlidingWindowVisualizer,
+  CallStackVisualizer,
+  GraphBFSVisualizer,
+  GraphDFSVisualizer,
+  DPTableVisualizer,
+  LinkedListCycleVisualizer,
+  HeapVisualizer,
+  TrieVisualizer,
+  BitVisualizer,
+  ConsistentHashRingVisualizer,
+  GeneratorVisualizer,
 }
 
 export function CustomMDX(props: MDXRemoteProps) {

--- a/src/app/components/prototype-chain-visualizer.tsx
+++ b/src/app/components/prototype-chain-visualizer.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+type Level = {
+  label: string
+  sub: string
+  has: string[]
+}
+
+const LEVELS: Level[] = [
+  { label: 'dog', sub: "{ name: 'Rex' }", has: ['name'] },
+  { label: 'Dog.prototype', sub: '{ bark() }', has: ['bark'] },
+  { label: 'Animal.prototype', sub: '{ eat() }', has: ['eat'] },
+  { label: 'Object.prototype', sub: '{ toString(), … }', has: ['toString', 'hasOwnProperty'] },
+  { label: 'null', sub: 'end of the chain', has: [] },
+]
+
+type Step = {
+  active: number // index into LEVELS currently being checked, -1 = idle
+  found?: number // index where the property was found
+  note: string
+}
+
+// Walking the lookup of dog.eat()
+const steps: Step[] = [
+  {
+    active: -1,
+    note: 'We call dog.eat(). The engine needs to find an "eat" property. Press play to watch it walk the chain.',
+  },
+  {
+    active: 0,
+    note: 'Check the instance dog itself. It only has "name" — miss. Follow the [[Prototype]] link up.',
+  },
+  {
+    active: 1,
+    note: 'Check Dog.prototype. It has "bark" but no "eat" — miss. Keep walking up the chain.',
+  },
+  {
+    active: 2,
+    found: 2,
+    note: 'Check Animal.prototype. It has "eat" — hit! The engine stops here and calls it with this = dog.',
+  },
+]
+
+export function PrototypeChainVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <div className="flex flex-col items-center gap-0">
+              {LEVELS.map((level, i) => {
+                const isNull = level.label === 'null'
+                const isActive = step.active === i
+                const isFound = step.found === i
+                const isChecked = step.active >= 0 && i < step.active
+                return (
+                  <div key={level.label} className="flex flex-col items-center">
+                    {i > 0 && (
+                      <div className="flex flex-col items-center">
+                        <div
+                          className={[
+                            'h-6 w-0.5 transition-colors duration-200',
+                            step.active >= i
+                              ? 'bg-neutral-400 dark:bg-neutral-500'
+                              : 'bg-neutral-200 dark:bg-neutral-700',
+                          ].join(' ')}
+                        />
+                        <span className="mb-1 font-mono text-[10px] text-neutral-400 dark:text-neutral-500">
+                          [[Prototype]] ↑
+                        </span>
+                      </div>
+                    )}
+                    {isNull ? (
+                      <span className="font-mono text-xs text-neutral-400 dark:text-neutral-500">
+                        null — top of the chain
+                      </span>
+                    ) : (
+                      <div
+                        className={[
+                          'w-56 rounded-lg border px-3 py-2 text-center transition-all duration-300',
+                          isFound
+                            ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
+                            : isActive
+                              ? 'border-amber-500 bg-amber-500 text-white'
+                              : isChecked
+                                ? 'border-neutral-200 bg-neutral-50 text-neutral-400 line-through dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-600'
+                                : 'border-neutral-200 bg-neutral-100 text-neutral-700 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
+                        ].join(' ')}
+                      >
+                        <div className="font-mono text-xs">{level.label}</div>
+                        <div
+                          className={[
+                            'font-mono text-[10px]',
+                            isActive || isFound
+                              ? 'text-white/80'
+                              : 'text-neutral-400 dark:text-neutral-500',
+                          ].join(' ')}
+                        >
+                          {level.sub}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/sliding-window-visualizer.tsx
+++ b/src/app/components/sliding-window-visualizer.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+const ARRAY = [2, 1, 5, 1, 3, 2]
+const K = 3
+
+type Step = {
+  start: number
+  end: number // inclusive right edge of the window
+  sum: number
+  best: number
+  note: string
+}
+
+// Fixed-size window of length K, tracking the max sum.
+const steps: Step[] = [
+  { start: 0, end: 2, sum: 8, best: 8, note: 'Build the first window of size 3: [2, 1, 5] = 8. That is our best so far.' },
+  { start: 1, end: 3, sum: 7, best: 8, note: 'Slide right by one: drop 2 (the old left), add 1 (the new right). Sum = 8 − 2 + 1 = 7. Best stays 8.' },
+  { start: 2, end: 4, sum: 9, best: 9, note: 'Slide again: drop 1, add 3. Sum = 7 − 1 + 3 = 9. New best!' },
+  { start: 3, end: 5, sum: 6, best: 9, note: 'Slide again: drop 5, add 2. Sum = 9 − 5 + 2 = 6. Best stays 9.' },
+  { start: 3, end: 5, sum: 6, best: 9, note: 'Done in one pass. The answer is 9 — computed in O(n), not the O(n·k) a naive re-sum would cost.' },
+]
+
+export function SlidingWindowVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <div className="flex justify-center gap-1.5">
+              {ARRAY.map((value, i) => {
+                const inWindow = i >= step.start && i <= step.end
+                return (
+                  <div key={i} className="flex flex-col items-center gap-1">
+                    <div
+                      className={[
+                        'flex h-11 w-11 items-center justify-center rounded-md font-mono text-sm transition-all duration-300',
+                        inWindow
+                          ? 'bg-green-600 text-white dark:bg-green-500'
+                          : 'bg-neutral-100 text-neutral-400 dark:bg-neutral-800 dark:text-neutral-600',
+                      ].join(' ')}
+                    >
+                      {value}
+                    </div>
+                    <span className="font-mono text-[10px] text-neutral-400 tabular-nums dark:text-neutral-500">
+                      {i}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="mt-3 flex justify-center gap-6 font-mono text-xs">
+              <span className="text-neutral-600 dark:text-neutral-300">
+                window sum ={' '}
+                <span className="text-green-600 dark:text-green-500">{step.sum}</span>
+              </span>
+              <span className="text-neutral-600 dark:text-neutral-300">
+                best ={' '}
+                <span className="text-amber-500">{step.best}</span>
+              </span>
+            </div>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}

--- a/src/app/components/trie-visualizer.tsx
+++ b/src/app/components/trie-visualizer.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { StepNote, StepPlayer } from '@/app/components/step-player'
+
+type TNode = { id: string; char: string; x: number; y: number; end?: boolean }
+
+const NODES: TNode[] = [
+  { id: 'root', char: '•', x: 150, y: 22 },
+  { id: 'c', char: 'c', x: 95, y: 78 },
+  { id: 'd', char: 'd', x: 235, y: 78 },
+  { id: 'ca', char: 'a', x: 95, y: 134 },
+  { id: 'do', char: 'o', x: 235, y: 134 },
+  { id: 'cat', char: 't', x: 45, y: 190, end: true },
+  { id: 'car', char: 'r', x: 135, y: 190 },
+  { id: 'dog', char: 'g', x: 235, y: 190, end: true },
+  { id: 'card', char: 'd', x: 135, y: 246, end: true },
+]
+
+const EDGES: [string, string][] = [
+  ['root', 'c'],
+  ['root', 'd'],
+  ['c', 'ca'],
+  ['d', 'do'],
+  ['ca', 'cat'],
+  ['ca', 'car'],
+  ['do', 'dog'],
+  ['car', 'card'],
+]
+
+const POS = new Map(NODES.map((n) => [n.id, n]))
+
+type Step = {
+  path: string[] // matched node ids so far
+  current?: string
+  found?: boolean
+  note: string
+}
+
+// Searching for the word "card".
+const steps: Step[] = [
+  { path: ['root'], current: 'root', note: 'A trie stores words as paths of characters. We search for "card", starting at the root.' },
+  { path: ['root', 'c'], current: 'c', note: "Look for a child labelled 'c'. It exists — follow it. The words 'cat', 'car', 'card' all share this edge." },
+  { path: ['root', 'c', 'ca'], current: 'ca', note: "Match 'a'. This one node is shared by every word starting 'ca' — that shared prefix is the whole point of a trie." },
+  { path: ['root', 'c', 'ca', 'car'], current: 'car', note: "Match 'r'. We are at 'car' — but it is not marked as a word end here in our set, so 'car' alone would be a prefix, not a stored word." },
+  { path: ['root', 'c', 'ca', 'car', 'card'], current: 'card', found: true, note: "Match 'd', and this node is a word end. Found 'card' in 4 steps — proportional to the word length, not the number of words stored." },
+]
+
+export function TrieVisualizer() {
+  return (
+    <StepPlayer length={steps.length} interval={1600}>
+      {(index) => {
+        const step = steps[index]
+        return (
+          <>
+            <svg
+              viewBox="0 0 300 275"
+              className="mx-auto block w-full max-w-xs"
+              role="img"
+              aria-label="Trie (prefix tree) with a search path highlighted"
+            >
+              {EDGES.map(([a, b], i) => {
+                const pa = POS.get(a)!
+                const pb = POS.get(b)!
+                const onPath =
+                  step.path.includes(a) && step.path.includes(b)
+                return (
+                  <line
+                    key={i}
+                    x1={pa.x}
+                    y1={pa.y}
+                    x2={pb.x}
+                    y2={pb.y}
+                    className={
+                      onPath
+                        ? 'stroke-green-500'
+                        : 'stroke-neutral-200 dark:stroke-neutral-700'
+                    }
+                    strokeWidth={onPath ? 2 : 1.5}
+                  />
+                )
+              })}
+              {NODES.map((n) => {
+                const isCurrent = step.current === n.id
+                const onPath = step.path.includes(n.id)
+                const isFound = isCurrent && step.found
+                return (
+                  <g key={n.id}>
+                    {n.end && (
+                      <circle
+                        cx={n.x}
+                        cy={n.y}
+                        r={19}
+                        className="fill-none stroke-neutral-300 dark:stroke-neutral-600"
+                        strokeWidth={1}
+                      />
+                    )}
+                    <circle
+                      cx={n.x}
+                      cy={n.y}
+                      r={15}
+                      className={
+                        isFound
+                          ? 'fill-green-600 dark:fill-green-500'
+                          : isCurrent
+                            ? 'fill-amber-500'
+                            : onPath
+                              ? 'fill-green-600/70 dark:fill-green-500/70'
+                              : 'fill-neutral-100 dark:fill-neutral-800'
+                      }
+                    />
+                    <text
+                      x={n.x}
+                      y={n.y + 4}
+                      textAnchor="middle"
+                      className={[
+                        'font-mono text-[12px]',
+                        isCurrent || onPath || isFound
+                          ? 'fill-white'
+                          : 'fill-neutral-700 dark:fill-neutral-300',
+                      ].join(' ')}
+                    >
+                      {n.char}
+                    </text>
+                  </g>
+                )
+              })}
+            </svg>
+            <p className="mt-1 text-center font-mono text-[10px] text-neutral-400 dark:text-neutral-500">
+              double-ringed nodes mark the end of a stored word
+            </p>
+            <StepNote>{step.note}</StepNote>
+          </>
+        )
+      }}
+    </StepPlayer>
+  )
+}


### PR DESCRIPTION
Make the prototype chain diagram an interactive step-through animation
(PrototypeChainVisualizer) and expand the prototypes post with sections
on dynamic lookup cost and instanceof.

Add 10 new posts, each with a bespoke StepPlayer-driven animation:
- Two pointers & sliding window
- Recursion & the call stack
- Graph traversal (BFS vs DFS)
- Dynamic programming (memoization to tabulation)
- Linked lists & Floyd's cycle detection
- Heaps & priority queues
- Tries (prefix trees)
- Bit manipulation fundamentals
- Consistent hashing
- JavaScript generators & iterators

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Amf8upJTFaUTX8WmCUktsq