### PR TITLE
Redesign site with warm editorial theme

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -88,13 +88,23 @@ export default async function Blog({
         }}
       />
 
-      <div className="mb-10 pb-8 border-b border-neutral-100 dark:border-neutral-800">
-        <h1 className="title font-semibold text-2xl tracking-tight text-neutral-900 dark:text-neutral-50 mb-3">
+      <div className="mb-10 pb-8 border-b border-line">
+        <h1 className="title font-bold text-3xl sm:text-4xl tracking-tight text-ink">
           {post.metadata.title}
         </h1>
-        <p className="text-sm text-neutral-500 dark:text-neutral-400">
-          {formatDate(post.metadata.publishedAt)} · {readingTime} min read
-        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <p className="text-sm text-muted">
+            {formatDate(post.metadata.publishedAt)} · {readingTime} min read
+          </p>
+          {post.metadata.tags?.map((t) => (
+            <span
+              key={t}
+              className="rounded-full border border-line bg-surface px-2.5 py-0.5 text-[11px] text-muted"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
       </div>
 
       <article className="prose">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -18,39 +18,40 @@ export default async function Page({
 
   return (
     <section>
-      <h1 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
-        Blog
+      <h1 className="mb-3 text-3xl sm:text-4xl font-bold tracking-tight text-ink">
+        Writing
+        <span className="text-accent">.</span>
       </h1>
-      <p className="mb-6 text-sm text-neutral-500 dark:text-neutral-400">
+      <p className="mb-8 leading-relaxed text-ink/70">
         Notes on data structures & algorithms, system design, and things I
         learn along the way.
       </p>
 
       <Link
         href="/dsa"
-        className="group mb-8 flex items-center justify-between gap-4 rounded-xl border border-neutral-100 dark:border-neutral-800 px-4 py-3 hover:border-green-600/40 dark:hover:border-green-500/40 transition-colors"
+        className="group mb-8 flex items-center justify-between gap-4 rounded-2xl bg-gradient-to-r from-accent to-accent-2 px-5 py-4 text-white shadow-sm hover:shadow-md transition-shadow"
       >
-        <span className="text-sm text-neutral-600 dark:text-neutral-300">
+        <span className="text-sm font-medium">
           Learning DSA?{' '}
-          <span className="text-neutral-500 dark:text-neutral-400">
+          <span className="font-normal text-white/75">
             Follow the structured path — ordered articles from recursion to
             dynamic programming.
           </span>
         </span>
-        <span className="shrink-0 text-sm text-green-600 dark:text-green-400 group-hover:translate-x-0.5 transition-transform">
+        <span className="shrink-0 group-hover:translate-x-0.5 transition-transform">
           →
         </span>
       </Link>
 
       {tags.length > 0 && (
-        <div className="mb-8 flex flex-wrap gap-1">
+        <div className="mb-8 flex flex-wrap gap-2">
           <Link
             href="/blog"
             className={[
-              'px-3 py-1 rounded-md text-xs transition-colors',
+              'px-3 py-1 rounded-full text-xs border transition-colors',
               !tag
-                ? 'text-neutral-900 dark:text-neutral-50 font-medium bg-neutral-100 dark:bg-neutral-800'
-                : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-900',
+                ? 'border-accent bg-accent text-white font-medium'
+                : 'border-line bg-surface text-muted hover:border-accent/50 hover:text-ink',
             ].join(' ')}
           >
             All
@@ -60,10 +61,10 @@ export default async function Page({
               key={t}
               href={`/blog?tag=${encodeURIComponent(t)}`}
               className={[
-                'px-3 py-1 rounded-md text-xs transition-colors',
+                'px-3 py-1 rounded-full text-xs border transition-colors',
                 tag === t
-                  ? 'text-neutral-900 dark:text-neutral-50 font-medium bg-neutral-100 dark:bg-neutral-800'
-                  : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-900',
+                  ? 'border-accent bg-accent text-white font-medium'
+                  : 'border-line bg-surface text-muted hover:border-accent/50 hover:text-ink',
               ].join(' ')}
             >
               {t}

--- a/src/app/components/copy-button.tsx
+++ b/src/app/components/copy-button.tsx
@@ -15,10 +15,10 @@ export function CopyButton({ code }: { code: string }) {
     <button
       onClick={copy}
       aria-label={copied ? 'Copied' : 'Copy code'}
-      className="absolute top-3 right-3 rounded-md border border-neutral-200 bg-white/80 p-1.5 text-neutral-400 opacity-0 backdrop-blur transition-opacity hover:text-neutral-700 focus:opacity-100 group-hover:opacity-100 dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-500 dark:hover:text-neutral-200"
+      className="absolute top-3 right-3 rounded-md border border-line bg-surface/80 p-1.5 text-muted opacity-0 backdrop-blur transition-opacity hover:text-ink focus:opacity-100 group-hover:opacity-100"
     >
       {copied ? (
-        <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current text-green-600 dark:text-green-500" aria-hidden>
+        <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current text-accent" aria-hidden>
           <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
         </svg>
       ) : (

--- a/src/app/components/copy-link-button.tsx
+++ b/src/app/components/copy-link-button.tsx
@@ -15,7 +15,7 @@ export function CopyLinkButton({ url }: { url: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="text-left text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+      className="text-left text-muted hover:text-ink transition-colors"
     >
       {copied ? 'Copied!' : 'Copy link'}
     </button>

--- a/src/app/components/dsa-path.tsx
+++ b/src/app/components/dsa-path.tsx
@@ -84,10 +84,10 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
 
   return (
     <div>
-      <div className="mb-10 rounded-xl border border-neutral-100 dark:border-neutral-800 p-4">
+      <div className="mb-10 rounded-xl border border-line bg-surface p-4">
         <div className="flex items-baseline justify-between gap-4">
-          <p className="text-sm text-neutral-600 dark:text-neutral-300">
-            <span className="font-medium text-neutral-900 dark:text-neutral-50 tabular-nums">
+          <p className="text-sm text-ink/80">
+            <span className="font-medium text-ink tabular-nums">
               {hydrated ? completedCount : 0}
             </span>{' '}
             of {readableSlugs.length} articles read
@@ -95,19 +95,19 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
           {hydrated && completedCount > 0 && (
             <button
               onClick={reset}
-              className="text-xs text-neutral-400 dark:text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+              className="text-xs text-muted hover:text-ink transition-colors"
             >
               Reset progress
             </button>
           )}
         </div>
-        <div className="mt-3 h-1.5 rounded-full bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
+        <div className="mt-3 h-1.5 rounded-full bg-line overflow-hidden">
           <div
-            className="h-full rounded-full bg-green-600 dark:bg-green-500 transition-all duration-300"
+            className="h-full rounded-full bg-accent transition-all duration-300"
             style={{ width: `${hydrated ? percent : 0}%` }}
           />
         </div>
-        <p className="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
+        <p className="mt-2 text-xs text-muted">
           Progress is saved in your browser.
         </p>
       </div>
@@ -116,34 +116,34 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
         {phases.map((phase, phaseIndex) => (
           <section key={phase.title}>
             <div className="mb-4 flex items-baseline gap-3">
-              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800 text-xs font-medium text-neutral-600 dark:text-neutral-300 tabular-nums">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-line bg-surface text-xs font-medium text-muted tabular-nums">
                 {phaseIndex + 1}
               </span>
               <div>
-                <h2 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+                <h2 className="text-lg font-semibold tracking-tight text-ink">
                   {phase.title}
                 </h2>
-                <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+                <p className="mt-1 text-sm text-muted">
                   {phase.description}
                 </p>
               </div>
             </div>
 
-            <ol className="ml-3 border-l border-neutral-100 dark:border-neutral-800 space-y-1">
+            <ol className="ml-3 border-l border-line space-y-1">
               {phase.items.map((item) => {
                 const isDone = hydrated && !!item.slug && done.has(item.slug)
                 return (
                   <li key={item.slug ?? item.title} className="relative pl-6">
                     <span
                       className={[
-                        'absolute -left-[5px] top-5 h-[9px] w-[9px] rounded-full border-2 border-white dark:border-neutral-950',
+                        'absolute -left-[5px] top-5 h-[9px] w-[9px] rounded-full border-2 border-bg',
                         isDone
-                          ? 'bg-green-600 dark:bg-green-500'
-                          : 'bg-neutral-200 dark:bg-neutral-700',
+                          ? 'bg-accent'
+                          : 'bg-line',
                       ].join(' ')}
                     />
                     {item.slug ? (
-                      <div className="group flex items-start gap-3 rounded-lg py-3 px-3 -mx-3 hover:bg-neutral-50 dark:hover:bg-neutral-900/50 transition-colors">
+                      <div className="group flex items-start gap-3 rounded-lg py-3 px-3 -mx-3 hover:bg-surface transition-colors">
                         <button
                           onClick={() => toggle(item.slug!)}
                           aria-label={
@@ -155,8 +155,8 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
                           className={[
                             'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border transition-colors',
                             isDone
-                              ? 'border-green-600 dark:border-green-500 bg-green-600 dark:bg-green-500 text-white'
-                              : 'border-neutral-300 dark:border-neutral-600 text-transparent hover:border-green-600 dark:hover:border-green-500',
+                              ? 'border-accent bg-accent text-white'
+                              : 'border-line text-transparent hover:border-accent',
                           ].join(' ')}
                         >
                           <svg
@@ -182,8 +182,8 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
                               className={[
                                 'font-medium transition-colors',
                                 isDone
-                                  ? 'text-neutral-400 dark:text-neutral-500 line-through decoration-neutral-300 dark:decoration-neutral-600'
-                                  : 'text-neutral-800 dark:text-neutral-200 group-hover:text-green-600 dark:group-hover:text-green-400',
+                                  ? 'text-muted line-through decoration-line'
+                                  : 'text-ink group-hover:text-accent',
                               ].join(' ')}
                             >
                               {item.title}
@@ -197,29 +197,29 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
                               {item.difficulty}
                             </span>
                             {item.readingTime && (
-                              <span className="text-xs text-neutral-400 dark:text-neutral-500">
+                              <span className="text-xs text-muted">
                                 {item.readingTime} min
                               </span>
                             )}
                           </div>
-                          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+                          <p className="mt-1 text-sm text-muted">
                             {item.note}
                           </p>
                         </div>
                       </div>
                     ) : (
                       <div className="flex items-start gap-3 py-3 px-3 -mx-3 opacity-60">
-                        <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-dashed border-neutral-300 dark:border-neutral-600" />
+                        <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-dashed border-line" />
                         <div className="min-w-0">
                           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                            <span className="font-medium text-neutral-500 dark:text-neutral-400">
+                            <span className="font-medium text-muted">
                               {item.title}
                             </span>
-                            <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-800">
+                            <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted bg-line/50">
                               Coming soon
                             </span>
                           </div>
-                          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+                          <p className="mt-1 text-sm text-muted">
                             {item.note}
                           </p>
                         </div>

--- a/src/app/components/dsa-path.tsx
+++ b/src/app/components/dsa-path.tsx
@@ -22,8 +22,7 @@ export type PathPhase = {
 const STORAGE_KEY = 'dsa-path-progress'
 
 const difficultyStyles: Record<Difficulty, string> = {
-  Beginner:
-    'text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/60',
+  Beginner: 'text-accent bg-accent/10',
   Intermediate:
     'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/60',
   Advanced: 'text-rose-700 dark:text-rose-400 bg-rose-50 dark:bg-rose-950/60',
@@ -57,6 +56,12 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
     readableSlugs.length === 0
       ? 0
       : Math.round((completedCount / readableSlugs.length) * 100)
+
+  const nextSlug = hydrated
+    ? phases
+        .flatMap((phase) => phase.items)
+        .find((item) => item.slug && !done.has(item.slug))?.slug
+    : undefined
 
   function toggle(slug: string) {
     setDone((prev) => {
@@ -92,18 +97,23 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
             </span>{' '}
             of {readableSlugs.length} articles read
           </p>
-          {hydrated && completedCount > 0 && (
-            <button
-              onClick={reset}
-              className="text-xs text-muted hover:text-ink transition-colors"
-            >
-              Reset progress
-            </button>
-          )}
+          <div className="flex items-baseline gap-3">
+            {hydrated && completedCount > 0 && (
+              <button
+                onClick={reset}
+                className="text-xs text-muted hover:text-ink transition-colors"
+              >
+                Reset progress
+              </button>
+            )}
+            <span className="text-sm font-semibold text-accent tabular-nums">
+              {hydrated ? percent : 0}%
+            </span>
+          </div>
         </div>
         <div className="mt-3 h-1.5 rounded-full bg-line overflow-hidden">
           <div
-            className="h-full rounded-full bg-accent transition-all duration-300"
+            className="h-full rounded-full bg-gradient-to-r from-accent to-accent-2 transition-all duration-300"
             style={{ width: `${hydrated ? percent : 0}%` }}
           />
         </div>
@@ -113,15 +123,34 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
       </div>
 
       <div className="space-y-12">
-        {phases.map((phase, phaseIndex) => (
+        {phases.map((phase, phaseIndex) => {
+          const phaseSlugs = phase.items
+            .filter((item) => item.slug)
+            .map((item) => item.slug!)
+          const phaseDone = phaseSlugs.filter((slug) => done.has(slug)).length
+          const phaseComplete =
+            hydrated && phaseSlugs.length > 0 && phaseDone === phaseSlugs.length
+          return (
           <section key={phase.title}>
             <div className="mb-4 flex items-baseline gap-3">
-              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-line bg-surface text-xs font-medium text-muted tabular-nums">
+              <span
+                className={[
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-medium tabular-nums transition-colors',
+                  phaseComplete
+                    ? 'border-accent bg-accent text-white'
+                    : 'border-line bg-surface text-muted',
+                ].join(' ')}
+              >
                 {phaseIndex + 1}
               </span>
               <div>
                 <h2 className="text-lg font-semibold tracking-tight text-ink">
                   {phase.title}
+                  {hydrated && phaseSlugs.length > 0 && (
+                    <span className="ml-2.5 align-middle text-xs font-normal text-muted tabular-nums">
+                      {phaseDone}/{phaseSlugs.length}
+                    </span>
+                  )}
                 </h2>
                 <p className="mt-1 text-sm text-muted">
                   {phase.description}
@@ -188,6 +217,11 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
                             >
                               {item.title}
                             </Link>
+                            {item.slug === nextSlug && (
+                              <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium text-white">
+                                Up next
+                              </span>
+                            )}
                             <span
                               className={[
                                 'rounded px-1.5 py-0.5 text-[10px] font-medium',
@@ -230,7 +264,8 @@ export function DsaPath({ phases }: { phases: PathPhase[] }) {
               })}
             </ol>
           </section>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -1,23 +1,35 @@
+const links = [
+  { name: 'RSS', href: '/rss', external: false },
+  { name: 'GitHub', href: 'https://github.com/adarshm07', external: true },
+  { name: 'X', href: 'https://x.com/adarshm07', external: true },
+  {
+    name: 'LinkedIn',
+    href: 'https://www.linkedin.com/in/adarshm07/',
+    external: true,
+  },
+]
+
 export default function Footer() {
   return (
-    <footer className="mt-16 pt-8 border-t border-neutral-100 dark:border-neutral-800">
-      <div className="flex items-center justify-between text-sm text-neutral-400 dark:text-neutral-500">
-        <p>© {new Date().getFullYear()} Adarsh M.</p>
+    <footer className="mt-20 pt-8 pb-10 border-t border-line">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <p className="text-xs text-muted">
+          © {new Date().getFullYear()} Adarsh M
+          <span className="text-accent">.</span>
+        </p>
         <div className="flex gap-5">
-          <a
-            href="/rss"
-            className="hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
-          >
-            RSS
-          </a>
-          <a
-            href="https://github.com/adarshm07"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
-          >
-            GitHub
-          </a>
+          {links.map((link) => (
+            <a
+              key={link.name}
+              href={link.href}
+              {...(link.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+              className="text-xs text-muted hover:text-accent transition-colors"
+            >
+              {link.name}
+            </a>
+          ))}
         </div>
       </div>
     </footer>

--- a/src/app/components/nav.tsx
+++ b/src/app/components/nav.tsx
@@ -4,33 +4,45 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 const navItems: Record<string, { name: string }> = {
-  '/': { name: 'home' },
-  '/blog': { name: 'blog' },
-  'mailto:contact@adarshm.com': { name: 'contact' },
+  '/blog': { name: 'Blog' },
+  '/dsa': { name: 'DSA' },
+  'mailto:contact@adarshm.com': { name: 'Contact' },
 }
 
 export function Navbar() {
   const pathname = usePathname()
 
   return (
-    <nav className="mb-12 flex items-center gap-1 border-b border-neutral-100 dark:border-neutral-800 pb-6">
-      {Object.entries(navItems).map(([path, { name }]) => {
-        const isActive = pathname === path
-        return (
-          <Link
-            key={path}
-            href={path}
-            className={[
-              'px-3 py-1.5 rounded-md text-sm transition-colors',
-              isActive
-                ? 'text-neutral-900 dark:text-neutral-50 font-medium bg-neutral-100 dark:bg-neutral-800'
-                : 'text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-900',
-            ].join(' ')}
-          >
-            {name}
-          </Link>
-        )
-      })}
+    <nav className="mb-12 flex items-center justify-between border-b border-line pb-5">
+      <Link href="/" className="group flex items-center gap-2.5">
+        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-accent to-accent-2 text-[13px] font-bold text-white shadow-sm">
+          AM
+        </span>
+        <span className="font-semibold tracking-tight text-ink group-hover:text-accent transition-colors">
+          Adarsh M
+        </span>
+      </Link>
+
+      <div className="flex items-center gap-5">
+        {Object.entries(navItems).map(([path, { name }]) => {
+          const isActive =
+            pathname === path || (path !== '/' && pathname.startsWith(`${path}/`))
+          return (
+            <Link
+              key={path}
+              href={path}
+              className={[
+                'text-sm transition-colors',
+                isActive
+                  ? 'font-medium text-accent'
+                  : 'text-muted hover:text-ink',
+              ].join(' ')}
+            >
+              {name}
+            </Link>
+          )
+        })}
+      </div>
     </nav>
   )
 }

--- a/src/app/components/post-sidebar.tsx
+++ b/src/app/components/post-sidebar.tsx
@@ -16,7 +16,7 @@ export function PostSidebar({
   return (
     <aside className="hidden xl:block fixed right-[max(1rem,calc(50%-608px))] top-32 w-52">
       <div className="mb-8">
-        <p className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+        <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted">
           Share
         </p>
         <div className="flex flex-col gap-2 text-xs">
@@ -24,7 +24,7 @@ export function PostSidebar({
             href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+            className="text-muted hover:text-ink transition-colors"
           >
             Share on X
           </a>
@@ -32,7 +32,7 @@ export function PostSidebar({
             href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+            className="text-muted hover:text-ink transition-colors"
           >
             Share on LinkedIn
           </a>
@@ -42,7 +42,7 @@ export function PostSidebar({
 
       {related.length > 0 && (
         <div>
-          <p className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+          <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted">
             Related
           </p>
           <ul className="space-y-3 text-xs">
@@ -50,7 +50,7 @@ export function PostSidebar({
               <li key={post.slug}>
                 <Link
                   href={`/blog/${post.slug}`}
-                  className="block leading-snug text-neutral-600 dark:text-neutral-300 hover:text-green-700 dark:hover:text-green-400 transition-colors"
+                  className="block leading-snug text-ink/80 hover:text-accent transition-colors"
                 >
                   {post.metadata.title}
                 </Link>

--- a/src/app/components/posts.tsx
+++ b/src/app/components/posts.tsx
@@ -1,5 +1,16 @@
 import Link from 'next/link'
-import { formatDate, getBlogPosts, getReadingTime } from '@/app/blog/utils'
+import { getBlogPosts, getReadingTime } from '@/app/blog/utils'
+
+function shortDate(date: string) {
+  if (!date.includes('T')) {
+    date = `${date}T00:00:00`
+  }
+  return new Date(date).toLocaleString('en-us', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
 
 export function BlogPosts({
   limit,
@@ -19,44 +30,61 @@ export function BlogPosts({
     )
     .slice(0, limit)
 
+  if (!showSummary) {
+    return (
+      <div className="divide-y divide-line">
+        {allBlogs.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="group flex items-baseline justify-between gap-4 py-3.5"
+          >
+            <span className="font-medium text-ink group-hover:text-accent transition-colors">
+              {post.metadata.title}
+            </span>
+            <span className="shrink-0 text-xs text-muted tabular-nums">
+              {shortDate(post.metadata.publishedAt)}
+            </span>
+          </Link>
+        ))}
+      </div>
+    )
+  }
+
   return (
-    <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
+    <div className="space-y-3">
       {allBlogs.map((post) => (
         <Link
           key={post.slug}
           href={`/blog/${post.slug}`}
-          className="group block py-4 -mx-3 px-3 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-900/50 transition-colors"
+          className="group block rounded-xl border border-line bg-surface px-5 py-4 transition-all hover:border-accent/60 hover:shadow-[0_2px_16px_rgba(42,46,58,0.06)]"
         >
-          <div className="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
-            <span className="text-sm text-neutral-400 dark:text-neutral-500 tabular-nums shrink-0">
-              {formatDate(post.metadata.publishedAt, false)}
-            </span>
-            <span className="font-medium text-neutral-800 dark:text-neutral-200 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors">
+          <div className="flex items-baseline justify-between gap-4">
+            <span className="font-semibold text-ink group-hover:text-accent transition-colors">
               {post.metadata.title}
             </span>
-            {showSummary && (
-              <span className="text-xs text-neutral-400 dark:text-neutral-500 shrink-0 sm:ml-auto">
-                {getReadingTime(post.content)} min read
-              </span>
-            )}
+            <span className="shrink-0 text-xs text-muted tabular-nums">
+              {shortDate(post.metadata.publishedAt)}
+            </span>
           </div>
-          {showSummary && post.metadata.summary && (
-            <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400 line-clamp-2">
+          {post.metadata.summary && (
+            <p className="mt-1.5 text-sm text-muted line-clamp-2">
               {post.metadata.summary}
             </p>
           )}
-          {showSummary && post.metadata.tags && post.metadata.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-2">
-              {post.metadata.tags.map((t) => (
-                <span
-                  key={t}
-                  className="text-xs text-neutral-400 dark:text-neutral-500"
-                >
-                  #{t}
-                </span>
-              ))}
-            </div>
-          )}
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {post.metadata.tags?.map((t) => (
+              <span
+                key={t}
+                className="rounded-full bg-bg px-2.5 py-0.5 text-[11px] text-muted"
+              >
+                {t}
+              </span>
+            ))}
+            <span className="ml-auto text-[11px] text-muted">
+              {getReadingTime(post.content)} min read
+            </span>
+          </div>
         </Link>
       ))}
     </div>

--- a/src/app/components/profile.tsx
+++ b/src/app/components/profile.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import { getGithubProfile } from '@/app/lib/github'
 
 const LINKEDIN_URL = 'https://www.linkedin.com/in/adarshm07/'
@@ -31,65 +30,63 @@ export async function Profile() {
   const profile = await getGithubProfile()
 
   const name = profile?.name ?? 'Adarsh M'
-  const avatarUrl = profile?.avatar_url ?? null
   const twitterUsername = profile?.twitter_username ?? 'adarshm07'
   const githubUrl = profile?.html_url ?? 'https://github.com/adarshm07'
 
-  return (
-    <div className="flex flex-col sm:flex-row sm:items-center gap-5">
-      {avatarUrl && (
-        <Image
-          src={avatarUrl}
-          alt={name}
-          width={64}
-          height={64}
-          className="rounded-full ring-2 ring-neutral-100 dark:ring-neutral-800 shrink-0"
-          priority
-        />
-      )}
+  const chipClass =
+    'inline-flex items-center gap-1.5 rounded-full border border-line bg-surface px-3.5 py-1.5 text-xs font-medium text-ink/80 hover:border-accent/60 hover:text-accent transition-colors'
 
-      <div className="flex-1 min-w-0">
-        <h1 className="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+  return (
+    <div>
+        <span className="inline-flex items-center gap-2 rounded-full border border-line bg-surface px-3 py-1 text-xs font-medium text-ink/80">
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-60" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-accent" />
+          </span>
+          Software Engineer · Kerala, India
+        </span>
+
+        <h1 className="mt-6 text-5xl sm:text-6xl font-bold tracking-tight text-ink">
           {name}
+          <span className="text-accent">.</span>
         </h1>
-        <p className="mt-1.5 text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
-          Software engineer based in Kerala, India. I write here as I learn —
-          data structures & algorithms, system design, and other things I
-          pick up along the way.
+
+        <p className="mt-6 max-w-xl text-lg leading-relaxed text-ink/70">
+          I write here as I learn — data structures & algorithms, system
+          design, and other things I pick up along the way.
         </p>
 
-        <div className="mt-3 flex items-center gap-3">
+        <div className="mt-8 flex flex-wrap items-center gap-2.5">
           <a
             href={githubUrl}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="GitHub"
-            className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+            className={chipClass}
           >
             <GithubIcon />
+            GitHub
           </a>
           {twitterUsername && (
             <a
               href={`https://x.com/${twitterUsername}`}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="X / Twitter"
-              className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+              className={chipClass}
             >
               <TwitterIcon />
+              Twitter
             </a>
           )}
           <a
             href={LINKEDIN_URL}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="LinkedIn"
-            className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+            className={chipClass}
           >
             <LinkedInIcon />
+            LinkedIn
           </a>
         </div>
-      </div>
     </div>
   )
 }

--- a/src/app/components/projects.tsx
+++ b/src/app/components/projects.tsx
@@ -29,14 +29,14 @@ export async function Projects() {
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+        <h2 className="text-xs font-medium uppercase tracking-widest text-muted">
           Projects
         </h2>
         <a
           href="https://github.com/adarshm07?tab=repositories"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+          className="text-xs text-muted hover:text-accent transition-colors"
         >
           View all →
         </a>
@@ -49,21 +49,21 @@ export async function Projects() {
             href={repo.html_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group flex flex-col rounded-lg border border-neutral-100 dark:border-neutral-800 p-4 hover:border-green-200 dark:hover:border-green-900 hover:bg-neutral-50 dark:hover:bg-neutral-900/60 transition-all"
+            className="group flex flex-col rounded-lg border border-line bg-surface p-4 hover:border-accent/60 transition-all"
           >
-            <span className="mb-1 font-medium text-sm text-neutral-800 dark:text-neutral-200 group-hover:text-green-700 dark:group-hover:text-green-400 transition-colors truncate">
+            <span className="mb-1 font-medium text-sm text-ink group-hover:text-accent transition-colors truncate">
               {repo.name}
             </span>
 
             {repo.description ? (
-              <span className="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-2 mb-3 flex-1">
+              <span className="text-xs text-muted line-clamp-2 mb-3 flex-1">
                 {repo.description}
               </span>
             ) : (
               <span className="flex-1" />
             )}
 
-            <div className="flex items-center gap-3 text-xs text-neutral-400 dark:text-neutral-500">
+            <div className="flex items-center gap-3 text-xs text-muted">
               {repo.language && (
                 <span className="flex items-center gap-1.5">
                   <span

--- a/src/app/components/reading-progress.tsx
+++ b/src/app/components/reading-progress.tsx
@@ -29,7 +29,7 @@ export function ReadingProgress() {
   return (
     <div className="fixed top-0 left-0 right-0 h-0.5 z-50">
       <div
-        className="h-full bg-green-600 dark:bg-green-500"
+        className="h-full bg-accent"
         style={{ width: `${progress * 100}%` }}
       />
     </div>

--- a/src/app/components/toc.tsx
+++ b/src/app/components/toc.tsx
@@ -43,7 +43,7 @@ export function TableOfContents() {
       aria-label="Table of contents"
       className="hidden xl:block fixed left-[max(1rem,calc(50%-608px))] top-32 w-52 max-h-[70vh] overflow-y-auto"
     >
-      <p className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+      <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted">
         On this page
       </p>
       <ul className="space-y-2">
@@ -54,8 +54,8 @@ export function TableOfContents() {
               className={[
                 'block border-l-2 pl-3 text-xs leading-relaxed transition-colors',
                 activeId === heading.id
-                  ? 'border-green-600 text-green-700 dark:text-green-400 font-medium'
-                  : 'border-neutral-100 dark:border-neutral-800 text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200',
+                  ? 'border-accent text-accent font-medium'
+                  : 'border-line text-muted hover:text-ink',
               ].join(' ')}
             >
               {heading.text}

--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -46,18 +46,42 @@ export default function Page() {
     }),
   }))
 
+  const totalArticles = phases.reduce(
+    (n, phase) => n + phase.items.filter((item) => item.slug).length,
+    0
+  )
+  const totalMinutes = phases.reduce(
+    (n, phase) =>
+      n + phase.items.reduce((m, item) => m + (item.readingTime ?? 0), 0),
+    0
+  )
+
   return (
     <section>
       <h1 className="mb-3 text-3xl sm:text-4xl font-bold tracking-tight text-ink">
         Learn DSA
         <span className="text-accent">.</span>
       </h1>
-      <p className="mb-8 leading-relaxed text-ink/70">
+      <p className="mb-5 leading-relaxed text-ink/70">
         A structured path through data structures and algorithms. The articles
         build on each other, so follow the order if you&apos;re starting fresh —
         or jump to whatever you want to brush up on. Most posts include
         interactive visualizations you can step through.
       </p>
+      <div className="mb-8 flex flex-wrap gap-2">
+        {[
+          `${totalArticles} articles`,
+          `${phases.length} phases`,
+          `~${totalMinutes} min of reading`,
+        ].map((stat) => (
+          <span
+            key={stat}
+            className="rounded-full border border-line bg-surface px-3 py-1 text-xs font-medium text-ink/80"
+          >
+            {stat}
+          </span>
+        ))}
+      </div>
       <DsaPath phases={phases} />
     </section>
   )

--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -48,10 +48,11 @@ export default function Page() {
 
   return (
     <section>
-      <h1 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+      <h1 className="mb-3 text-3xl sm:text-4xl font-bold tracking-tight text-ink">
         Learn DSA
+        <span className="text-accent">.</span>
       </h1>
-      <p className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+      <p className="mb-8 leading-relaxed text-ink/70">
         A structured path through data structures and algorithms. The articles
         build on each other, so follow the order if you&apos;re starting fresh —
         or jump to whatever you want to brush up on. Most posts include

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,5 +1,46 @@
 @import "tailwindcss";
 
+/* ── Palette ─────────────────────────────────────────────── */
+
+:root {
+  --bg: #faf6ef;
+  --surface: #ffffff;
+  --text: #2a2e3a;
+  --accent: #4f8a8b;
+  --accent-2: #3b4a6b;
+  --muted: #8a8f9c;
+  --line: #e8e1d4;
+  --glow: rgba(79, 138, 139, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1e222c;
+    --surface: #262b37;
+    --text: #e9e7e1;
+    --accent: #74c0c1;
+    --accent-2: #9fb2d6;
+    --muted: #9aa0ad;
+    --line: #343a48;
+    --glow: rgba(79, 138, 139, 0.1);
+  }
+  html {
+    color-scheme: dark;
+  }
+}
+
+@theme inline {
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, monospace;
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-ink: var(--text);
+  --color-accent: var(--accent);
+  --color-accent-2: var(--accent-2);
+  --color-muted: var(--muted);
+  --color-line: var(--line);
+}
+
 /* sugar-high syntax colors — light */
 :root {
   --sh-class: #2d5e9d;
@@ -25,20 +66,17 @@
     --sh-property: #f69d50;
     --sh-entity: #f69d50;
   }
-  html {
-    color-scheme: dark;
-  }
 }
 
 ::selection {
-  background-color: #dcfce7;
-  color: #14532d;
+  background-color: #d8eaea;
+  color: #1f3d3e;
 }
 
 @media (prefers-color-scheme: dark) {
   ::selection {
-    background-color: #14532d;
-    color: #dcfce7;
+    background-color: #2f5253;
+    color: #dff1f1;
   }
 }
 
@@ -78,74 +116,46 @@ html {
 
 .prose .anchor:after {
   content: "#";
-  color: #d1d5db;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose .anchor:after {
-    color: #374151;
-  }
+  color: var(--muted);
+  opacity: 0.6;
 }
 
 .prose a {
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-thickness: 1px;
-  text-decoration-color: #d1d5db;
+  text-decoration-color: var(--line);
   transition: text-decoration-color 0.15s;
 }
 
 .prose a:hover {
-  text-decoration-color: #16a34a;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose a {
-    text-decoration-color: #374151;
-  }
-  .prose a:hover {
-    text-decoration-color: #22c55e;
-  }
+  text-decoration-color: var(--accent);
 }
 
 .prose pre {
   @apply rounded-xl overflow-x-auto py-4 px-5 text-sm my-6;
-  background-color: #f6f8fa;
-  border: 1px solid #d1d9e0;
+  background-color: var(--surface);
+  border: 1px solid var(--line);
   line-height: 1.7;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose pre {
-    background-color: #0d1117;
-    border-color: #21262d;
-  }
 }
 
 .prose code {
   @apply px-1.5 py-0.5 rounded-md text-sm;
-  background-color: #f3f4f6;
-  color: #111827;
+  background-color: #f1ece1;
+  color: var(--text);
 }
 
 @media (prefers-color-scheme: dark) {
   .prose code {
-    background-color: #1f2937;
-    color: #e5e7eb;
+    background-color: #303646;
   }
 }
 
 .prose pre code {
   @apply p-0 text-sm;
   background-color: transparent;
-  color: #1f2328;
+  color: var(--text);
   border: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose pre code {
-    color: #e6edf3;
-  }
 }
 
 .prose code span {
@@ -158,53 +168,32 @@ html {
 
 .prose p {
   @apply my-5 leading-relaxed;
-  color: #374151;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose p {
-    color: #d1d5db;
-  }
+  color: var(--text);
 }
 
 .prose h1 {
   @apply text-3xl font-semibold tracking-tight mt-10 mb-4;
-  color: #111827;
+  color: var(--text);
 }
 
 .prose h2 {
   @apply text-2xl font-semibold tracking-tight mt-10 mb-3;
-  color: #111827;
+  color: var(--text);
 }
 
 .prose h3 {
   @apply text-xl font-semibold tracking-tight mt-8 mb-3;
-  color: #111827;
+  color: var(--text);
 }
 
 .prose h4 {
   @apply text-lg font-semibold tracking-tight mt-6 mb-2;
-  color: #111827;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose h1,
-  .prose h2,
-  .prose h3,
-  .prose h4 {
-    color: #f9fafb;
-  }
+  color: var(--text);
 }
 
 .prose strong {
   @apply font-semibold;
-  color: #111827;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose strong {
-    color: #f3f4f6;
-  }
+  color: var(--text);
 }
 
 .prose ul {
@@ -216,36 +205,18 @@ html {
 }
 
 .prose li {
-  color: #374151;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose li {
-    color: #d1d5db;
-  }
+  color: var(--text);
 }
 
 .prose blockquote {
   @apply border-l-4 pl-4 my-6 italic;
-  border-color: #16a34a;
-  color: #6b7280;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose blockquote {
-    color: #9ca3af;
-  }
+  border-color: var(--accent-2);
+  color: var(--muted);
 }
 
 .prose hr {
   @apply my-8;
-  border-color: #f3f4f6;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose hr {
-    border-color: #1f2937;
-  }
+  border-color: var(--line);
 }
 
 .prose > :first-child {
@@ -260,29 +231,12 @@ html {
 .prose th,
 .prose td {
   @apply border px-3 py-2 text-left;
-  border-color: #e5e7eb;
+  border-color: var(--line);
+  color: var(--text);
 }
 
 .prose th {
   @apply font-semibold;
-  color: #111827;
-}
-
-.prose td {
-  color: #374151;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose th,
-  .prose td {
-    border-color: #1f2937;
-  }
-  .prose th {
-    color: #f9fafb;
-  }
-  .prose td {
-    color: #d1d5db;
-  }
 }
 
 /* ── Utilities ───────────────────────────────────────────── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,9 +72,13 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${GeistSans.variable} ${GeistMono.variable} text-black bg-white dark:text-white dark:bg-[#0a0a0a]`}
+      className={`${GeistSans.variable} ${GeistMono.variable} text-ink bg-bg`}
     >
       <body className="antialiased max-w-2xl mx-4 mt-8 lg:mx-auto">
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-x-0 top-0 -z-10 h-80 bg-[radial-gradient(70%_100%_at_50%_0%,var(--glow),transparent_70%)]"
+        />
         <main className="flex-auto min-w-0 mt-6 flex flex-col px-2 md:px-0">
           <Navbar />
           {children}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,10 +1,10 @@
 export default function NotFound() {
   return (
     <section>
-      <h1 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+      <h1 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
         404
       </h1>
-      <p className="text-neutral-500 dark:text-neutral-400">
+      <p className="text-muted">
         This page could not be found.
       </p>
     </section>

--- a/src/app/og/route.tsx
+++ b/src/app/og/route.tsx
@@ -7,24 +7,24 @@ export function GET(request: Request) {
   return new ImageResponse(
     (
       <div
-        tw="flex flex-col w-full h-full justify-between bg-white p-20"
+        tw="flex flex-col w-full h-full justify-between bg-[#FAF6EF] p-20"
         style={{
           backgroundImage:
-            'radial-gradient(circle at 25px 25px, #e5e7eb 2%, transparent 0%), radial-gradient(circle at 75px 75px, #e5e7eb 2%, transparent 0%)',
+            'radial-gradient(circle at 25px 25px, #E8E1D4 2%, transparent 0%), radial-gradient(circle at 75px 75px, #E8E1D4 2%, transparent 0%)',
           backgroundSize: '100px 100px',
         }}
       >
         <div tw="flex items-center">
-          <div tw="h-4 w-4 rounded-full bg-green-600 mr-4" />
-          <span tw="text-2xl font-semibold text-neutral-500">adarshm.com</span>
+          <div tw="h-4 w-4 rounded-full bg-[#4F8A8B] mr-4" />
+          <span tw="text-2xl font-semibold text-[#8A8F9C]">adarshm.com</span>
         </div>
         <h2
-          tw="flex text-6xl font-bold tracking-tight text-left text-neutral-900"
+          tw="flex text-6xl font-bold tracking-tight text-left text-[#2A2E3A]"
           style={{ lineHeight: 1.15 }}
         >
           {title}
         </h2>
-        <span tw="text-2xl text-neutral-500">
+        <span tw="text-2xl text-[#8A8F9C]">
           Adarsh M. — Software Engineer
         </span>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,13 +43,14 @@ export default function Page() {
       </Suspense>
 
       <div>
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
-            Writing
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="flex items-center gap-2.5 text-lg font-semibold tracking-tight text-ink">
+            <span className="h-5 w-1 rounded-full bg-gradient-to-b from-accent to-accent-2" />
+            Latest writing
           </h2>
           <Link
             href="/blog"
-            className="text-xs text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            className="text-sm text-muted hover:text-accent transition-colors"
           >
             View all →
           </Link>
@@ -62,11 +63,12 @@ export default function Page() {
 
 function ProfileSkeleton() {
   return (
-    <div className="flex items-center gap-5 animate-pulse">
-      <div className="h-16 w-16 rounded-full bg-neutral-100 dark:bg-neutral-800 shrink-0" />
-      <div className="flex-1 space-y-2">
-        <div className="h-6 w-40 rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="h-4 w-64 rounded bg-neutral-100 dark:bg-neutral-800" />
+    <div className="animate-pulse space-y-6">
+      <div className="h-6 w-56 rounded-full bg-line/50" />
+      <div className="h-14 w-72 rounded bg-line/50" />
+      <div className="space-y-2">
+        <div className="h-5 w-full max-w-xl rounded bg-line/50" />
+        <div className="h-5 w-80 rounded bg-line/50" />
       </div>
     </div>
   )


### PR DESCRIPTION
- New palette as CSS tokens: cream background, white surfaces, dark
  slate text, teal primary accent, navy secondary (light + derived
  dark mode) mapped into Tailwind via @theme
- Wire Geist Sans/Mono into Tailwind 4 theme (fonts were loaded but
  never applied)
- Nav: AM monogram tile wordmark, DSA link added, accent active state
- Hero: text-only editorial layout with status badge, larger name,
  and social link chips
- Home: compact post rows; blog: card-style post list with tag pills
  and gradient DSA banner
- Retheme post header, footer, TOC, sidebar, DSA path, OG image, and
  prose styles to palette tokens; add soft radial glow behind header

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F95vvwyNAqStAK9dtaUiPo