### PR TITLE
Add 16 new blog posts on DSA, JavaScript, TypeScript, and system design

### DIFF
--- a/src/app/blog/posts/async-await-under-the-hood.mdx
+++ b/src/app/blog/posts/async-await-under-the-hood.mdx
@@ -1,0 +1,166 @@
+---
+title: "Async/Await Under the Hood: Promises in Disguise"
+publishedAt: "2026-07-16"
+summary: "async/await isn't a new concurrency model — it's syntax sugar over promises and generators. Understanding the desugared version explains error handling, sequential-looking parallel bugs, and why 'async' functions always return a promise."
+tags: "JavaScript"
+---
+
+`async`/`await` reads like synchronous code, and that's precisely what
+makes it easy to misuse: it *feels* like execution pauses, but nothing
+about the event loop actually changed. Underneath, `async`/`await` is
+syntax sugar over promises — every `async` function is a function that
+returns a promise, and every `await` is a pause point implemented with the
+same mechanism generators use to suspend and resume.
+
+## What async actually does to a function
+
+An `async` function **always returns a promise**, even if the body
+returns a plain value or throws synchronously:
+
+```javascript
+async function getValue() {
+  return 42;
+}
+
+getValue(); // Promise { 42 }, not 42
+
+async function fails() {
+  throw new Error("nope");
+}
+
+fails().catch((e) => console.log(e.message)); // "nope" — the throw became a rejection
+```
+
+That's the whole contract: a plain `return` becomes `Promise.resolve(...)`,
+and a `throw` becomes a rejected promise. Nothing about calling an `async`
+function is actually synchronous from the caller's perspective — you
+always get a promise back, immediately, and the function's body may not
+have finished (or even started past the first `await`) by the time you
+have it.
+
+## What await actually does: suspend, don't block
+
+`await` does **not** block the thread. It suspends the `async` function at
+that point, registers a continuation to resume after the awaited promise
+settles, and immediately hands control back to the caller — the rest of
+the program keeps running on the same single thread. When the awaited
+promise resolves, the continuation is scheduled as a **microtask**.
+
+This is the mental model that clears up most `async`/`await` confusion:
+it desugars to roughly this generator-and-driver pattern.
+
+```javascript
+// Roughly what "async function" compiles down to
+function asyncToGenerator(generatorFn) {
+  return function (...args) {
+    const generator = generatorFn(...args);
+
+    return new Promise((resolve, reject) => {
+      function step(key, arg) {
+        let result;
+        try {
+          result = generator[key](arg); // .next(arg) or .throw(arg)
+        } catch (err) {
+          return reject(err);
+        }
+        const { value, done } = result;
+        if (done) return resolve(value);
+        Promise.resolve(value).then(
+          (val) => step("next", val),
+          (err) => step("throw", err)
+        );
+      }
+      step("next");
+    });
+  };
+}
+```
+
+Each `await expr` is a `yield expr` in the underlying generator: the
+generator pauses, the driver wraps the yielded value in
+`Promise.resolve()`, and resumes the generator (`.next()` or `.throw()`)
+only once that promise settles. That's the entire mechanism — no threads,
+no blocking, just a promise chain with generator syntax on top.
+
+## Why sequential await is slower than it needs to be
+
+Because each `await` genuinely pauses the function until that specific
+promise settles, awaiting independent operations one after another forces
+them to run **sequentially** even when they don't depend on each other:
+
+```javascript
+// Sequential — total time ≈ sum of both
+async function slow() {
+  const user = await fetchUser();     // waits here
+  const posts = await fetchPosts();   // doesn't start until user resolves
+  return { user, posts };
+}
+
+// Concurrent — total time ≈ the slower of the two
+async function fast() {
+  const [user, posts] = await Promise.all([fetchUser(), fetchPosts()]);
+  return { user, posts };
+}
+```
+
+`fetchUser()` and `fetchPosts()` don't depend on each other, so starting
+both before awaiting either lets them run concurrently — the promises are
+created immediately (kicking off the underlying work) and only
+*awaited* together. This is the single most common `async`/`await`
+performance bug: reaching for `await` reflexively on every line, turning
+what should be parallel I/O into an accidental waterfall.
+
+## for await and sequential loops are sometimes the point
+
+Not every sequential `await` is a bug — sometimes the next step
+genuinely depends on the previous one (pagination, rate-limited APIs,
+retries). The tell is whether the *data* has a dependency, not whether the
+code happens to be written as a loop:
+
+```javascript
+// Correct to be sequential — each page's cursor comes from the last
+async function fetchAllPages(url) {
+  const results = [];
+  let cursor = null;
+  do {
+    const page = await fetch(`${url}?cursor=${cursor}`).then((r) => r.json());
+    results.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return results;
+}
+```
+
+## Error handling: try/catch replaces .catch()
+
+Because `await` unwraps a promise into a value or throws, ordinary
+`try`/`catch` works for async code the same way it works for synchronous
+code — a rejected awaited promise is just a thrown exception at that line:
+
+```javascript
+async function safeFetch(url) {
+  try {
+    const res = await fetch(url);
+    return await res.json();
+  } catch (err) {
+    console.error("Request failed:", err);
+    return null;
+  }
+}
+```
+
+One trap: forgetting `await` on a call inside the `try` block means the
+returned promise's eventual rejection happens **after** the function has
+already returned, outside the `try`/`catch`'s reach — an unhandled
+rejection instead of a caught error.
+
+## Wrap-up
+
+`async`/`await` doesn't introduce a new concurrency primitive — it's
+generator-based syntax sugar over the same promise microtask queue that's
+always been there. `async` guarantees the return value is a promise;
+`await` suspends the function and resumes it as a microtask once the
+awaited promise settles, without ever blocking the thread. Knowing that
+desugared shape is what makes the difference between code that reads
+sequential and code that accidentally *runs* sequential when it didn't
+need to.

--- a/src/app/blog/posts/bloom-filters-explained.mdx
+++ b/src/app/blog/posts/bloom-filters-explained.mdx
@@ -1,0 +1,159 @@
+---
+title: "Bloom Filters: Probably in the Set, Definitely Not"
+publishedAt: "2026-07-14"
+summary: "A probabilistic data structure that answers set-membership queries in constant space by allowing false positives but never false negatives — and why Chrome, Cassandra, and CDNs all rely on that trade."
+tags: "DSA, System Design"
+---
+
+Suppose you need to check "have I seen this before?" against a set with
+billions of entries — malicious URLs, cached keys, usernames already taken.
+A hash set answers correctly but costs one entry's worth of memory per
+item. A **Bloom filter** answers the same question in a fixed, tiny amount
+of memory, no matter how many items you insert — by accepting a small,
+tunable rate of **false positives** in exchange.
+
+## The core trick: many hashes, one bit array
+
+A Bloom filter is a bit array of size `m`, all zeros to start, plus `k`
+independent hash functions. To **add** an item, hash it `k` ways and set
+those `k` bit positions to 1. To **check membership**, hash it the same
+`k` ways and see if all `k` bits are set.
+
+```javascript
+class BloomFilter {
+  constructor(size = 1000, hashCount = 3) {
+    this.size = size;
+    this.hashCount = hashCount;
+    this.bits = new Uint8Array(size);
+  }
+
+  #hash(item, seed) {
+    let h = seed;
+    for (let i = 0; i < item.length; i++) {
+      h = (Math.imul(h, 31) + item.charCodeAt(i)) | 0;
+    }
+    return Math.abs(h) % this.size;
+  }
+
+  add(item) {
+    for (let i = 0; i < this.hashCount; i++) {
+      this.bits[this.#hash(item, i)] = 1;
+    }
+  }
+
+  mightContain(item) {
+    for (let i = 0; i < this.hashCount; i++) {
+      if (!this.bits[this.#hash(item, i)]) return false; // definitely absent
+    }
+    return true; // probably present
+  }
+}
+```
+
+Notice the asymmetry baked into the name: `mightContain` is honest about
+what it can promise. If *any* of the `k` bits is 0, the item was
+**definitely never added** — no hash function would have skipped setting
+a bit it was supposed to set. But if all `k` bits are 1, that's not proof;
+some other combination of items could have set every one of those bits
+without this exact item ever being inserted. Hence: **no false negatives,
+possible false positives**.
+
+## Why bits collide, and why that's the whole trade-off
+
+Two different items can share a bit position purely by hash collision.
+As more items get added, the bit array fills up with 1s, and the chance
+that an absent item's `k` positions all happen to already be set — a
+false positive — climbs. There's no false-positive-free way around this;
+it's the price of representing unbounded set membership in fixed space.
+
+The false-positive rate is well-approximated by:
+
+```
+p ≈ (1 − e^(−kn/m))^k
+```
+
+where `n` is the number of inserted items, `m` the bit array size, and `k`
+the hash count. Three levers, one trade-off:
+
+- **Bigger `m`** (more bits) → lower `p`, more memory.
+- **More items `n`** → higher `p` for a fixed `m` — the filter degrades as
+  it fills up, it doesn't fail outright.
+- **Tuning `k`** — too few hashes under-spreads the bits, too many
+  saturates the array faster than it needs to. The optimum is
+  `k ≈ (m/n) · ln(2)`, which is where most implementations land.
+
+## Why not just use a hash set?
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Hash set</th>
+      <th>Bloom filter</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Space per item</td>
+      <td>Full key (+ overhead)</td>
+      <td>A handful of bits, regardless of key size</td>
+    </tr>
+    <tr>
+      <td>False positives</td>
+      <td>None</td>
+      <td>Tunable, non-zero</td>
+    </tr>
+    <tr>
+      <td>False negatives</td>
+      <td>None</td>
+      <td>Never</td>
+    </tr>
+    <tr>
+      <td>Deletion</td>
+      <td>O(1)</td>
+      <td>Not supported (unsetting a bit can un-add other items)</td>
+    </tr>
+    <tr>
+      <td>Stores the actual keys</td>
+      <td>Yes</td>
+      <td>No — can't enumerate or retrieve them</td>
+    </tr>
+  </tbody>
+</table>
+
+That last row matters as much as the space savings: a Bloom filter can
+never tell you *what's* in the set, only whether a specific query might
+be. It's a pure membership oracle, not a container.
+
+## Where the "probably" is good enough
+
+- **Chrome's Safe Browsing** used to ship a Bloom filter of known-malicious
+  URLs to the client: a lookup that says "definitely safe" skips a network
+  call entirely; a "might be unsafe" hit triggers one extra round-trip to
+  double-check against the real list. Correctness is never compromised —
+  it just filters out most of the negative case cheaply.
+- **Cassandra, HBase, and other LSM-tree databases** keep a Bloom filter
+  per on-disk file. Before doing an expensive disk read to check if a key
+  exists in that file, they check the filter first — a "definitely not
+  here" answer skips the disk seek entirely, which is the whole reason
+  reads on LSM stores stay fast despite data being spread across many
+  files.
+- **CDNs and caches** use them to avoid caching one-hit-wonders: only
+  promote a resource into the expensive cache tier once the filter has
+  seen it before, filtering out the long tail of URLs that are requested
+  exactly once.
+
+In every case, the pattern is the same: use the Bloom filter as a cheap
+**pre-check** in front of something expensive (a disk read, a network
+call, a cache write), and let it save you from doing that expensive thing
+whenever it can answer "definitely not" with certainty.
+
+## Wrap-up
+
+A Bloom filter trades perfect accuracy for constant, tiny memory: it can
+say "definitely not in the set" with full confidence, and "probably in the
+set" with a tunable error rate — never the reverse. That one-sided
+guarantee is exactly what you want as a gatekeeper in front of an
+expensive lookup, which is why it shows up quietly inside browsers,
+databases, and caches wherever "skip the expensive check most of the time"
+is the goal.

--- a/src/app/blog/posts/caching-strategies-explained.mdx
+++ b/src/app/blog/posts/caching-strategies-explained.mdx
@@ -1,0 +1,169 @@
+---
+title: "Caching Strategies: Cache-Aside, Write-Through, and Write-Back"
+publishedAt: "2026-07-18"
+summary: "Adding a cache in front of a database is easy. Deciding when the cache gets populated and how writes stay consistent with the source of truth is where cache-aside, write-through, and write-back diverge — each trading latency against staleness risk differently."
+tags: "System Design"
+---
+
+"Just add a cache" is the easy part of scaling a read-heavy system. The
+hard part is deciding **when** the cache gets filled and **how** it stays
+consistent with the database once writes happen — and different answers
+to that question produce genuinely different systems, not just
+implementation details. The three dominant strategies — cache-aside,
+write-through, and write-back — each make a different trade between
+write latency, read latency, and the risk of serving stale data.
+
+## Cache-aside (lazy loading): the application drives the cache
+
+The application checks the cache first; on a **miss**, it reads from the
+database and populates the cache for next time. The cache never talks to
+the database directly — it's the application code that owns the whole
+flow.
+
+```javascript
+async function getUser(id) {
+  let user = await cache.get(`user:${id}`);
+  if (user) return user; // cache hit
+
+  user = await db.query("SELECT * FROM users WHERE id = ?", [id]);
+  await cache.set(`user:${id}`, user, { ttl: 300 }); // populate for next time
+  return user;
+}
+
+async function updateUser(id, changes) {
+  await db.update("users", id, changes);
+  await cache.delete(`user:${id}`); // invalidate — don't try to update the cache in place
+}
+```
+
+**Invalidate, don't update, on writes.** The tempting alternative —
+writing the new value directly into the cache after a database update —
+is a race-condition trap: two concurrent writes can interleave such that
+the cache ends up holding the *older* value even though the database has
+the newer one. Deleting the key and letting the next read repopulate it
+from the database sidesteps that race entirely, at the cost of one extra
+cache miss.
+
+- **Pro:** only requested data ever enters the cache — no wasted memory on
+  data nobody reads. Cache failure degrades gracefully to "every request
+  hits the database," rather than breaking writes.
+- **Con:** the first request for any key always misses (cold-cache
+  latency), and there's a window between a write and the next read where
+  a naive read-through-cache-only client could serve stale data if
+  invalidation is missed or delayed.
+
+## Write-through: the cache is updated in lockstep with the database
+
+Every write goes through the cache, which updates itself and the database
+**synchronously**, together, before the write is considered complete.
+
+```javascript
+async function updateUserWriteThrough(id, changes) {
+  const updated = await db.update("users", id, changes);
+  await cache.set(`user:${id}`, updated); // cache and DB updated together, in the write path
+  return updated;
+}
+```
+
+- **Pro:** the cache is never stale — a read right after a write always
+  sees the new value, because the cache was updated as part of the write
+  itself.
+- **Con:** every write now pays the latency of **two** operations (cache
+  write plus database write) instead of one, and data that's written but
+  never read still occupies cache space — write-through caches everything
+  that's written, not just what's requested.
+
+## Write-back (write-behind): the cache absorbs writes, the database catches up later
+
+Writes go to the cache **only**, immediately returning success, and the
+cache asynchronously flushes changes to the database later — either on a
+timer or when a slot needs to evict.
+
+```javascript
+async function updateUserWriteBack(id, changes) {
+  await cache.set(`user:${id}`, { ...changes, dirty: true });
+  return { success: true }; // returns before the DB write happens
+  // a background worker periodically flushes dirty entries to the database
+}
+```
+
+- **Pro:** write latency is as fast as the cache itself — the database's
+  latency is completely removed from the write's critical path. This also
+  lets you **batch and coalesce** writes: ten rapid updates to the same
+  key become one database write instead of ten.
+- **Con:** genuinely risky — if the cache crashes or the process dies
+  before the flush happens, unflushed writes are **lost**, because the
+  cache was the only place they existed. This strategy is only appropriate
+  when the cache has its own durability (persistence, replication) or the
+  data can tolerate loss.
+
+## Comparing the three
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Cache-aside</th>
+      <th>Write-through</th>
+      <th>Write-back</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Write latency</td>
+      <td>Fast (cache untouched on write)</td>
+      <td>Slow (cache + DB, synchronously)</td>
+      <td>Fastest (cache only, DB deferred)</td>
+    </tr>
+    <tr>
+      <td>Read-after-write consistency</td>
+      <td>Risk of stale read if invalidation lags</td>
+      <td>Always fresh</td>
+      <td>Always fresh (reads hit the cache)</td>
+    </tr>
+    <tr>
+      <td>Data loss risk</td>
+      <td>None — DB is always the source of truth</td>
+      <td>None — DB updated synchronously</td>
+      <td>Real, if the cache fails before flushing</td>
+    </tr>
+    <tr>
+      <td>Wasted cache space</td>
+      <td>None — only requested keys cached</td>
+      <td>Yes — everything written gets cached</td>
+      <td>Yes — everything written gets cached</td>
+    </tr>
+  </tbody>
+</table>
+
+## Picking one
+
+- **Cache-aside** is the default for most read-heavy web applications —
+  Redis or Memcached in front of a relational database, populated
+  on-demand. It's forgiving of cache outages and doesn't cache data nobody
+  asked for.
+- **Write-through** earns its extra write latency when read-after-write
+  freshness matters more than write speed — session state, user-facing
+  data where "I just saved this and it shows the old value" is a visible
+  bug.
+- **Write-back** is reserved for cases where write throughput is the
+  bottleneck and the cache itself is durable enough to trust — CPU cache
+  layers, some storage engines, and systems explicitly built with
+  replication or a write-ahead log underneath the cache tier to eliminate
+  the data-loss risk.
+
+They're also not mutually exclusive within one system — it's common to
+use cache-aside for most entities and write-through specifically for the
+handful of fields where staleness would be user-visible.
+
+## Wrap-up
+
+The question a caching strategy actually answers isn't "should I cache
+this," it's "when does the cache get populated, and what happens to the
+database on a write." Cache-aside keeps writes cheap and the cache lean at
+the cost of occasional stale reads; write-through keeps the cache always
+fresh at the cost of slower writes; write-back makes writes nearly free by
+deferring the database entirely, at the cost of real data-loss risk if the
+cache fails first. None of the three is universally "correct" — the right
+one depends on whether your system can tolerate stale reads, slow writes,
+or occasional loss, in that order of severity.

--- a/src/app/blog/posts/cap-theorem-and-eventual-consistency.mdx
+++ b/src/app/blog/posts/cap-theorem-and-eventual-consistency.mdx
@@ -1,0 +1,156 @@
+---
+title: "The CAP Theorem and Eventual Consistency, Explained"
+publishedAt: "2026-07-18"
+summary: "Every distributed database quietly picks a side in a trade-off it can't escape: when the network partitions, you serve either possibly-stale data or an error. CAP theorem names that choice — and explains why 'eventual consistency' is a deliberate design, not a bug."
+tags: "System Design"
+---
+
+Every distributed database's marketing page eventually mentions
+"consistency," "availability," or "partition tolerance" — and usually
+implies it has all three. It can't. The **CAP theorem** states that a
+distributed system can guarantee at most two of the three simultaneously,
+and in practice, one of those three isn't optional, which reduces the real
+choice to just one axis.
+
+## The three properties
+
+- **Consistency (C):** every read receives the most recent write, or an
+  error. All nodes see the same data at the same time — there's no such
+  thing as "node A already has the update, node B doesn't yet."
+- **Availability (A):** every request to a non-failing node receives a
+  response (not an error), though not necessarily the *most recent* data.
+- **Partition tolerance (P):** the system keeps operating even when
+  network failures split it into groups of nodes that can't communicate
+  with each other.
+
+## Why P isn't actually optional
+
+Network partitions — a switch failing, a link dropping, a data center
+losing connectivity — **will happen** in any real distributed system;
+it's not a design choice you get to opt out of, it's a physical certainty
+over a long enough timeline. That leaves only two real options once a
+partition occurs, which is why CAP is usually phrased not as "pick 2 of
+3" but as "**when a partition happens, pick C or A**":
+
+- **Choose consistency (CP):** during the partition, nodes that can't
+  confirm they have the latest data **refuse to serve requests** (or
+  return an error) rather than risk serving something stale or
+  conflicting. The system sacrifices availability to protect correctness.
+- **Choose availability (AP):** every node keeps answering requests during
+  the partition, even if it can't confirm it has the latest write —
+  meaning different nodes may return different, temporarily inconsistent
+  answers. The system sacrifices strict consistency to stay responsive.
+
+Outside of a partition, a well-designed system can be both consistent and
+available — the trade-off only bites during the partition itself. CAP is
+a statement about what you're forced to give up under failure, not a
+permanent handicap.
+
+## What real databases choose
+
+<table>
+  <thead>
+    <tr>
+      <th>System</th>
+      <th>Typical choice</th>
+      <th>Behavior during a partition</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Traditional RDBMS (single primary)</td>
+      <td>CP-leaning</td>
+      <td>Writes fail or block if the primary is unreachable</td>
+    </tr>
+    <tr>
+      <td>etcd, ZooKeeper, Consul</td>
+      <td>CP</td>
+      <td>Refuses writes without quorum — correctness over uptime, by design (they're used for coordination)</td>
+    </tr>
+    <tr>
+      <td>Cassandra, DynamoDB</td>
+      <td>AP (tunable)</td>
+      <td>Every reachable node answers; conflicts resolved later</td>
+    </tr>
+    <tr>
+      <td>MongoDB (default)</td>
+      <td>CP-leaning</td>
+      <td>Reads/writes route through the primary; secondaries can lag</td>
+    </tr>
+  </tbody>
+</table>
+
+Many modern databases don't hardcode the choice — they expose it as a
+tunable per-operation setting. Cassandra's consistency level (`ONE`,
+`QUORUM`, `ALL`) and DynamoDB's choice between eventually-consistent and
+strongly-consistent reads let *you* pick the trade-off per query instead
+of the database imposing one globally.
+
+## Eventual consistency: AP's actual promise
+
+Choosing availability doesn't mean giving up on consistency forever — it
+means deferring it. **Eventual consistency** is the guarantee that *if no
+new writes occur*, all replicas will eventually converge to the same
+value — "eventually," not "immediately." During the gap, different nodes
+can legitimately disagree.
+
+```javascript
+// Simplified: an AP-style key-value store during a partition
+// Node A (reachable by client 1):
+nodeA.set("cart:42", { items: 3 }); // accepted immediately
+
+// Node B (reachable by client 2, partitioned from A):
+nodeB.get("cart:42"); // might still return the OLD value, or nothing
+
+// Once the partition heals, replication catches up and both
+// nodes converge — "eventually" consistent.
+```
+
+The system remains **available** (both nodes answered) but was not
+**consistent** (they answered differently) during the partition — exactly
+the AP trade being made explicit.
+
+## Resolving conflicts once the partition heals
+
+Eventually-consistent systems need a rule for what happens when two
+replicas that diverged during a partition need to merge back into one
+value. Common approaches:
+
+- **Last-write-wins (LWW):** attach a timestamp to every write, keep the
+  newest. Simple, but can silently discard a legitimate concurrent write
+  if clocks aren't perfectly synchronized.
+- **Vector clocks:** track causality per replica so the system can detect
+  *"these two writes were genuinely concurrent, not one following the
+  other"* and surface the conflict instead of guessing — this is how
+  Amazon's original Dynamo paper handled shopping cart merges.
+- **CRDTs (Conflict-free Replicated Data Types):** data structures
+  specifically designed so that merging two divergent replicas always
+  produces a well-defined, consistent result with no manual conflict
+  resolution — a counter that only increments, or a set that only grows,
+  can always be merged unambiguously regardless of the order updates
+  arrive in.
+
+## Choosing CP or AP for your own system
+
+The right choice depends on what an inconsistency actually costs versus
+what an outage costs:
+
+- **Banking, inventory counts, anything where overselling or double
+  spending is the failure mode** → CP. A rejected request is recoverable;
+  a wrong balance is not.
+- **Social media feeds, product catalogs, shopping carts, view/like
+  counters** → AP. A slightly stale feed or an eventually-corrected cart
+  is a far better user experience than an error page during a network
+  blip.
+
+## Wrap-up
+
+CAP theorem isn't a checklist of features to pursue — it's a statement
+about an unavoidable trade-off during a network partition, which will
+happen. Partition tolerance isn't optional in any real distributed system,
+which leaves one genuine decision: refuse to answer when you can't
+guarantee freshness (CP), or answer anyway and let replicas reconcile
+afterward (AP, backed by eventual consistency and a conflict-resolution
+strategy like LWW, vector clocks, or CRDTs). Neither choice is universally
+right — it depends entirely on whether a stale answer or a failed request
+is the cheaper mistake for your system to make.

--- a/src/app/blog/posts/dijkstra-shortest-paths.mdx
+++ b/src/app/blog/posts/dijkstra-shortest-paths.mdx
@@ -1,0 +1,165 @@
+---
+title: "Dijkstra's Algorithm: Shortest Paths With a Priority Queue"
+publishedAt: "2026-07-15"
+summary: "BFS finds shortest paths when every edge costs the same. Dijkstra's algorithm generalizes that to weighted graphs by always expanding the closest unvisited node next — the algorithm behind every routing map you've used."
+tags: "DSA"
+---
+
+BFS finds the shortest path in an **unweighted** graph by exploring nodes
+in layers — everything one hop away, then two hops, and so on. That
+breaks the moment edges have different costs: a 1-hop path costing 100
+isn't shorter than a 3-hop path costing 3. **Dijkstra's algorithm** is
+BFS's generalization to weighted graphs (with the restriction that weights
+must be non-negative), and it's the algorithm underneath every
+"shortest route" feature in mapping software and network routing.
+
+## The greedy idea
+
+Dijkstra maintains a running "best known distance" to every node, starts
+at the source with distance 0 (everything else infinity), and repeatedly:
+
+1. Pick the **unvisited** node with the smallest known distance.
+2. Mark it visited — its distance is now final and will never improve.
+3. **Relax** its edges: for each neighbor, check if going through the
+   current node beats the neighbor's current best distance, and update if
+   so.
+
+Step 1 is why a **priority queue** (min-heap) is the right tool — "pick
+the smallest" is exactly what it's built for, in O(log n) instead of the
+O(n) a plain array scan would cost.
+
+```javascript
+function dijkstra(graph, source) {
+  // graph: Map<node, Array<[neighbor, weight]>>
+  const dist = new Map([[source, 0]]);
+  const visited = new Set();
+  const pq = new MinHeap(); // [distance, node]
+  pq.push([0, source]);
+
+  while (!pq.isEmpty()) {
+    const [d, node] = pq.pop();
+    if (visited.has(node)) continue;   // stale entry, see below
+    visited.add(node);
+
+    for (const [neighbor, weight] of graph.get(node) ?? []) {
+      const candidate = d + weight;
+      if (candidate < (dist.get(neighbor) ?? Infinity)) {
+        dist.set(neighbor, candidate);
+        pq.push([candidate, neighbor]);
+      }
+    }
+  }
+
+  return dist; // shortest distance from source to every reachable node
+}
+```
+
+## Why non-negative weights matter
+
+The whole algorithm rests on one guarantee: when a node is popped from the
+priority queue, its distance is **final** — nothing found later can beat
+it, because everything still in the queue has distance ≥ the one just
+popped, and adding a non-negative edge weight can only make a path
+*longer or equal*, never shorter.
+
+A negative edge breaks that guarantee outright: a node could be finalized
+with distance 10, then later a path through a `-5` edge reaches it in 3.
+Dijkstra has already moved on and won't revisit it — the negative edge
+poisons the greedy assumption. That's exactly the case **Bellman-Ford**
+exists for: it tolerates negative weights (and detects negative cycles) by
+relaxing every edge repeatedly instead of trusting a greedy pop, at the
+cost of O(V·E) instead of Dijkstra's O(E log V).
+
+## The stale-entry trick
+
+Notice the `if (visited.has(node)) continue;` line. Rather than
+*decreasing* a key already in the heap (which most binary heap
+implementations don't support directly), this implementation just pushes
+a fresh, better entry whenever a shorter distance is found, leaving the
+old, now-stale entry sitting in the heap. When that stale entry eventually
+gets popped, the `visited` check throws it away for free. It costs a bit
+of extra heap space but avoids implementing a decrease-key operation —
+the standard practical trade in a language without a built-in
+indexed-priority-queue.
+
+## Complexity
+
+<table>
+  <thead>
+    <tr>
+      <th>Implementation</th>
+      <th>Time</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Array scan for the minimum</td>
+      <td>O(V²)</td>
+      <td>Fine for dense graphs, simple to write</td>
+    </tr>
+    <tr>
+      <td>Binary heap priority queue</td>
+      <td>O((V + E) log V)</td>
+      <td>The standard choice for sparse graphs</td>
+    </tr>
+    <tr>
+      <td>Fibonacci heap</td>
+      <td>O(E + V log V)</td>
+      <td>Theoretically optimal; rarely worth the implementation cost</td>
+    </tr>
+  </tbody>
+</table>
+
+`E log V` dominates for sparse graphs (roads, most real networks), which
+is why the binary-heap version is the one you'll actually write.
+
+## Reconstructing the path, not just the distance
+
+Dijkstra as written only returns distances. To recover the actual
+shortest **path**, track a `previous` pointer whenever an edge relaxes a
+neighbor's distance, then walk it backward from destination to source:
+
+```javascript
+if (candidate < (dist.get(neighbor) ?? Infinity)) {
+  dist.set(neighbor, candidate);
+  previous.set(neighbor, node);   // remember how we got here
+  pq.push([candidate, neighbor]);
+}
+
+function reconstructPath(previous, target) {
+  const path = [target];
+  while (previous.has(path[path.length - 1])) {
+    path.push(previous.get(path[path.length - 1]));
+  }
+  return path.reverse();
+}
+```
+
+## Where it runs in production
+
+- **Map and routing software** — road networks are weighted graphs
+  (distance or travel time), and Dijkstra (or heavily optimized variants
+  like A*, contraction hierarchies, and bidirectional search) computes the
+  route.
+- **Network routing protocols** — OSPF (Open Shortest Path First) runs
+  Dijkstra over link costs to build each router's forwarding table.
+- **Game AI and level design** — pathfinding on a weighted grid (where
+  terrain has different movement costs) uses Dijkstra or its
+  heuristic-guided cousin A*.
+
+**A\*** is worth naming explicitly: it's Dijkstra plus a heuristic
+(straight-line distance to the goal, typically) that biases the search
+toward the destination instead of expanding uniformly in every direction —
+same correctness guarantee, usually far fewer nodes visited when there's a
+clear notion of "closer to the goal."
+
+## Wrap-up
+
+Dijkstra's algorithm is BFS's answer to weighted graphs: instead of
+exploring in uniform layers, always expand the unvisited node with the
+smallest known distance, using a priority queue to make "smallest" a cheap
+operation. It's correct exactly as long as weights stay non-negative — the
+moment a negative edge appears, reach for Bellman-Ford instead. Between
+maps, network routing, and pathfinding, it's one of the most-executed
+algorithms in the world, quietly running behind "get directions."

--- a/src/app/blog/posts/javascript-proxy-and-reflect.mdx
+++ b/src/app/blog/posts/javascript-proxy-and-reflect.mdx
@@ -1,0 +1,186 @@
+---
+title: "Proxy and Reflect: Intercepting JavaScript Objects"
+publishedAt: "2026-07-17"
+summary: "Proxy lets you intercept fundamental operations on an object — get, set, delete, has — before they happen. It's the mechanism behind Vue's reactivity, ORMs, and API validation layers."
+tags: "JavaScript"
+---
+
+Most JavaScript object access — `obj.prop`, `obj.prop = x`, `delete
+obj.prop`, `"prop" in obj` — happens directly against the object with no
+hook for you to observe or change it. `Proxy` changes that: it wraps a
+target object and lets you supply **traps**, functions that intercept
+these fundamental operations before they reach the target. It's how Vue 3
+implements reactivity, how many ORMs build query builders that look like
+plain object access, and how validation layers enforce schemas
+transparently.
+
+## The basic shape
+
+`new Proxy(target, handler)` returns an object that behaves like `target`
+in every way you don't explicitly intercept, and runs your trap for every
+way you do:
+
+```javascript
+const user = { name: "Ada", age: 30 };
+
+const logged = new Proxy(user, {
+  get(target, prop, receiver) {
+    console.log(`reading ${String(prop)}`);
+    return Reflect.get(target, prop, receiver);
+  },
+  set(target, prop, value, receiver) {
+    console.log(`writing ${String(prop)} = ${value}`);
+    return Reflect.set(target, prop, value, receiver);
+  },
+});
+
+logged.name;        // logs "reading name", returns "Ada"
+logged.age = 31;     // logs "writing age = 31", actually sets it
+```
+
+The proxy is transparent to consumers — `logged.name` looks and behaves
+exactly like reading a normal property. That transparency is the whole
+point: existing code that doesn't know about the proxy still works
+unmodified, while the traps run underneath.
+
+## Reflect: the default behavior, callable
+
+Every trap has a matching `Reflect` method that performs the operation's
+*default* behavior — `Reflect.get`, `Reflect.set`, `Reflect.has`,
+`Reflect.deleteProperty`, and so on. Inside a trap, calling the matching
+`Reflect` method (rather than touching `target` directly) is the standard
+pattern for "do the normal thing, but I got to look first":
+
+```javascript
+const validated = new Proxy({}, {
+  set(target, prop, value) {
+    if (prop === "age" && typeof value !== "number") {
+      throw new TypeError("age must be a number");
+    }
+    return Reflect.set(target, prop, value); // falls through to normal assignment
+  },
+});
+
+validated.age = 30;    // fine
+validated.age = "old"; // throws TypeError
+```
+
+Two reasons to prefer `Reflect.set(target, ...)` over `target[prop] =
+value` inside the trap: it correctly forwards the `receiver` argument
+(important for correctness with inheritance and getters/setters further
+up a prototype chain), and it **returns a boolean** indicating success
+instead of silently failing in non-strict mode — the `set` trap is
+required to return that boolean so `Proxy` can decide whether to throw on
+the caller's behalf.
+
+## The traps that matter most
+
+<table>
+  <thead>
+    <tr>
+      <th>Trap</th>
+      <th>Intercepts</th>
+      <th>Common use</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>get</code></td>
+      <td><code>obj.prop</code></td>
+      <td>Reactivity tracking, lazy computed properties, logging</td>
+    </tr>
+    <tr>
+      <td><code>set</code></td>
+      <td><code>obj.prop = x</code></td>
+      <td>Validation, reactivity change detection, read-only enforcement</td>
+    </tr>
+    <tr>
+      <td><code>has</code></td>
+      <td><code>"prop" in obj</code></td>
+      <td>Hiding private-ish properties from enumeration checks</td>
+    </tr>
+    <tr>
+      <td><code>deleteProperty</code></td>
+      <td><code>delete obj.prop</code></td>
+      <td>Protecting required fields, cascading cleanup</td>
+    </tr>
+    <tr>
+      <td><code>apply</code></td>
+      <td>Calling a proxied function</td>
+      <td>Argument logging, memoization wrappers, access control</td>
+    </tr>
+  </tbody>
+</table>
+
+## Reactivity: how Vue 3 tracks changes
+
+Vue 3's reactivity system (and similar libraries) is a thin `get`/`set`
+trap pair: reading a property inside a component's render function
+records "this component depends on this property"; writing to it later
+re-runs everything that recorded a dependency on it.
+
+```javascript
+function reactive(target, onChange) {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      track(obj, prop);                      // record: current effect reads this
+      return Reflect.get(obj, prop, receiver);
+    },
+    set(obj, prop, value, receiver) {
+      const result = Reflect.set(obj, prop, value, receiver);
+      trigger(obj, prop);                     // re-run everything that read this
+      return result;
+    },
+  });
+}
+```
+
+This is exactly why Vue 3 dropped `Object.defineProperty`-based
+reactivity (used in Vue 2): `Proxy` intercepts property **addition** and
+**deletion** too — operations `defineProperty` can't retroactively hook
+for keys that don't exist yet — and it works on arrays and `Map`/`Set`
+without special-casing index assignment or method calls.
+
+## Access control and API wrappers
+
+A `get` trap that throws on unknown properties turns silent `undefined`
+bugs (typo'd property names) into immediate errors — useful for
+enforcing a schema at the object boundary:
+
+```javascript
+function strict(target) {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      if (!(prop in obj)) {
+        throw new ReferenceError(`Unknown property: ${String(prop)}`);
+      }
+      return Reflect.get(obj, prop, receiver);
+    },
+  });
+}
+
+const config = strict({ timeout: 5000 });
+config.timeout;  // 5000
+config.timeuot;  // throws immediately instead of silently returning undefined
+```
+
+## What Proxy can't do
+
+`Proxy` can't intercept operations on **primitives** (numbers, strings,
+booleans aren't objects), and it can't make identity checks
+(`proxy === target`) return `true` — a proxy is a genuinely distinct
+object, which occasionally surprises code that relies on reference
+equality. It also carries a real performance cost versus direct property
+access, since every trapped operation is a function call — fine for
+config objects and reactivity systems, worth benchmarking before using in
+a hot loop over large datasets.
+
+## Wrap-up
+
+`Proxy` intercepts the fundamental operations JavaScript performs on
+objects — get, set, has, delete, and more — before they reach the real
+object, and `Reflect` gives you the matching default implementation to
+fall through to once your trap has done its job. Together they're the
+mechanism behind reactive frameworks, validation layers, and ORMs that
+make remote or computed data look like plain property access —
+interception without the caller ever needing to know.

--- a/src/app/blog/posts/kmp-string-matching.mdx
+++ b/src/app/blog/posts/kmp-string-matching.mdx
@@ -1,0 +1,181 @@
+---
+title: "KMP String Matching: Search Without Backtracking"
+publishedAt: "2026-07-16"
+summary: "The naive substring search re-checks characters it's already seen and degrades to O(nm) on adversarial input. The Knuth-Morris-Pratt algorithm precomputes a failure table so the search pointer never moves backward, guaranteeing O(n + m)."
+tags: "DSA"
+---
+
+`text.includes(pattern)` looks like a solved problem, but the naive
+algorithm underneath a straightforward implementation has a worst case
+that's easy to trigger by accident: searching for `"aaaaab"` inside
+`"aaaaaaaaaaaaaaaaaaaaaab"` re-scans huge overlapping stretches of the
+text on every failed attempt. The **Knuth-Morris-Pratt (KMP)** algorithm
+fixes this with one idea: when a match fails partway through, use what you
+already learned about the pattern to skip ahead in the text — never
+re-check a character you've already matched.
+
+## Why the naive approach backtracks
+
+The obvious algorithm tries every starting position in the text, and at
+each one, compares characters until a mismatch:
+
+```javascript
+function naiveSearch(text, pattern) {
+  const n = text.length, m = pattern.length;
+  for (let i = 0; i <= n - m; i++) {
+    let j = 0;
+    while (j < m && text[i + j] === pattern[j]) j++;
+    if (j === m) return i; // full match
+  }
+  return -1;
+}
+```
+
+The waste is in what happens on a mismatch: the outer loop advances `i` by
+just **one**, then the inner loop starts comparing from `j = 0` again —
+re-examining text characters that were already confirmed to match the
+pattern's prefix on the previous attempt. On pathological inputs (long
+runs of a repeated character followed by a near-miss), this degrades to
+O(n·m).
+
+## The insight: the pattern tells you where to resume
+
+Say you're matching pattern `"ABABC"` against the text and you've matched
+`"ABAB"` before hitting a mismatch on the 5th character. The naive
+algorithm would restart the whole comparison one position to the right.
+But look at what you already matched: `"ABAB"` has a prefix (`"AB"`) that
+is also a **suffix** of what matched so far. That means the text you just
+scanned already contains `"AB"` positioned exactly where the pattern's
+next attempt would need it — so instead of re-comparing those two
+characters, jump straight to comparing from that point.
+
+This is exactly what KMP precomputes once per pattern, independent of the
+text: for every prefix of the pattern, the length of the longest proper
+prefix that is also a suffix of it. That table is usually called the
+**LPS array** (Longest Proper Prefix which is also Suffix) or the failure
+function.
+
+```javascript
+function buildLPS(pattern) {
+  const m = pattern.length;
+  const lps = new Array(m).fill(0);
+  let len = 0; // length of the current matching prefix-suffix
+  let i = 1;
+
+  while (i < m) {
+    if (pattern[i] === pattern[len]) {
+      lps[i++] = ++len;
+    } else if (len > 0) {
+      len = lps[len - 1]; // fall back to the next-best prefix-suffix, don't reset to 0
+    } else {
+      lps[i++] = 0;
+    }
+  }
+
+  return lps;
+}
+
+buildLPS("ABABC"); // → [0, 0, 1, 2, 0]
+```
+
+Read `lps[i]` as "if the match fails right after matching `pattern[0..i]`,
+resume comparing at `pattern[lps[i]]` instead of `pattern[0]`" — that's
+the entire skip mechanism.
+
+## The search: the text pointer never goes backward
+
+With the LPS table built, the search itself uses it on every mismatch
+instead of restarting:
+
+```javascript
+function kmpSearch(text, pattern) {
+  const n = text.length, m = pattern.length;
+  if (m === 0) return 0;
+  const lps = buildLPS(pattern);
+
+  let i = 0; // text pointer
+  let j = 0; // pattern pointer
+  const matches = [];
+
+  while (i < n) {
+    if (text[i] === pattern[j]) {
+      i++;
+      j++;
+      if (j === m) {
+        matches.push(i - j); // found a match starting here
+        j = lps[j - 1];      // keep searching for overlapping matches
+      }
+    } else if (j > 0) {
+      j = lps[j - 1];        // fall back using the table — i never decreases
+    } else {
+      i++;                   // no partial match to fall back to
+    }
+  }
+
+  return matches;
+}
+```
+
+The property that makes this O(n + m): `i` only ever increases. On a
+mismatch, only `j` (the pattern pointer) falls back, using the
+precomputed table instead of scanning the text again — the text is read
+left to right exactly once.
+
+## Complexity
+
+<table>
+  <thead>
+    <tr>
+      <th>Algorithm</th>
+      <th>Time</th>
+      <th>Space</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Naive search</td>
+      <td>O(n·m) worst case</td>
+      <td>O(1)</td>
+    </tr>
+    <tr>
+      <td>KMP</td>
+      <td>O(n + m) guaranteed</td>
+      <td>O(m) for the LPS table</td>
+    </tr>
+    <tr>
+      <td>Rabin-Karp (rolling hash)</td>
+      <td>O(n + m) average, O(n·m) worst case</td>
+      <td>O(1)</td>
+    </tr>
+  </tbody>
+</table>
+
+**Rabin-Karp** is the other common answer to this problem: hash the
+pattern and every window of the text, comparing hashes instead of raw
+characters, updating the hash incrementally (a rolling hash) as the window
+slides. It's simpler to implement and generalizes nicely to searching for
+*multiple* patterns at once, but a hash collision degrades it back to
+character-by-character comparison, so its worst case isn't as tight as
+KMP's guarantee.
+
+## Where it matters
+
+- **Text editors and `grep`-like tools** — reliable linear-time substring
+  search regardless of input shape.
+- **Network intrusion detection (DPI)** — scanning packet payloads for
+  known malicious byte signatures needs a worst-case guarantee, since an
+  attacker can craft adversarial input specifically to trigger the naive
+  algorithm's slow path.
+- **Bioinformatics** — searching for a DNA/protein motif inside a genome,
+  where sequences are long, highly repetitive, and exactly the kind of
+  input that makes the naive algorithm's worst case realistic rather than
+  theoretical.
+
+## Wrap-up
+
+The naive substring search wastes work by discarding everything it
+learned on a failed attempt and starting over one position later. KMP
+fixes that by precomputing, for every prefix of the pattern, how much of a
+partial match can be reused after a mismatch — so the text pointer never
+moves backward and the whole search finishes in O(n + m), regardless of
+how adversarial the input is.

--- a/src/app/blog/posts/merge-intervals-and-greedy-scheduling.mdx
+++ b/src/app/blog/posts/merge-intervals-and-greedy-scheduling.mdx
@@ -1,0 +1,190 @@
+---
+title: "Merge Intervals and Greedy Interval Scheduling"
+publishedAt: "2026-07-15"
+summary: "Calendar conflicts, meeting rooms, and 'maximum non-overlapping tasks' are all interval problems that collapse into a single sort-then-scan pattern once you pick the right key to sort by."
+tags: "DSA"
+---
+
+A surprising number of scheduling problems — "does this meeting conflict
+with that one," "merge these overlapping bookings," "what's the maximum
+number of non-overlapping tasks I can fit" — reduce to the same shape:
+a list of `[start, end]` intervals. The trick that makes all of them
+tractable is the same in every case: **sort first**, so overlap becomes a
+simple adjacent-pair comparison instead of an all-pairs check.
+
+## Merging overlapping intervals
+
+Given a pile of intervals in arbitrary order, merge every group that
+overlaps into a single interval.
+
+```javascript
+function mergeIntervals(intervals) {
+  if (intervals.length <= 1) return intervals;
+
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  const merged = [sorted[0]];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const [start, end] = sorted[i];
+    const last = merged[merged.length - 1];
+
+    if (start <= last[1]) {
+      last[1] = Math.max(last[1], end); // overlaps — extend in place
+    } else {
+      merged.push([start, end]);        // no overlap — new group
+    }
+  }
+
+  return merged;
+}
+
+mergeIntervals([[1, 3], [2, 6], [8, 10], [15, 18]]);
+// → [[1, 6], [8, 10], [15, 18]]
+```
+
+Sorting by **start time** is what makes the single left-to-right scan
+correct: once intervals are in start order, the only interval that can
+possibly overlap the current group is the *next* one in line — anything
+further out starts even later. Without sorting, an overlap could hide
+anywhere in the list, forcing an O(n²) all-pairs check; with it, one pass
+suffices, for O(n log n) total dominated by the sort.
+
+## Detecting any conflict at all
+
+"Can I attend all these meetings?" is the merge check without the
+merging — sort by start, then see if any interval starts before the
+previous one ends:
+
+```javascript
+function canAttendAll(intervals) {
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i][0] < sorted[i - 1][1]) return false; // overlap found
+  }
+  return true;
+}
+```
+
+## The maximum non-overlapping subset — sort by the other key
+
+Here's the one that trips people up: "given overlapping intervals, what's
+the largest subset where none of them overlap?" (equivalently: "what's the
+minimum number to remove so none overlap?"). The instinct is to sort by
+start time again — but that's the wrong key for this problem.
+
+Sort by **end time** instead, then greedily keep any interval whose start
+is at or after the end of the last interval kept:
+
+```javascript
+function maxNonOverlapping(intervals) {
+  const sorted = [...intervals].sort((a, b) => a[1] - b[1]); // by END time
+  let count = 0;
+  let lastEnd = -Infinity;
+
+  for (const [start, end] of sorted) {
+    if (start >= lastEnd) {
+      count++;
+      lastEnd = end;
+    }
+  }
+
+  return count;
+}
+```
+
+**Why end time, not start time:** the greedy proof rests on always picking
+the interval that frees up the calendar **soonest**, leaving maximum room
+for everything after it. Among all intervals that could go first, the one
+ending earliest is never a worse choice than any alternative — any
+solution that picked a later-ending interval first could be swapped for
+the earliest-ending one without losing any options, so greedy-by-end-time
+never does worse than optimal. Sorting by start time doesn't have that
+property: a long interval that starts earliest can block out far more of
+the calendar than a short one, so committing to it first can strictly
+reduce how many intervals fit overall.
+
+## Inserting a new interval into a sorted, merged list
+
+A variant worth knowing: given an already-merged, sorted list of
+intervals, insert one new interval and re-merge only where necessary —
+without re-sorting everything.
+
+```javascript
+function insertInterval(intervals, newInterval) {
+  const result = [];
+  let [start, end] = newInterval;
+  let i = 0;
+
+  while (i < intervals.length && intervals[i][1] < start) {
+    result.push(intervals[i++]); // entirely before newInterval
+  }
+  while (i < intervals.length && intervals[i][0] <= end) {
+    start = Math.min(start, intervals[i][0]); // overlaps — absorb it
+    end = Math.max(end, intervals[i][1]);
+    i++;
+  }
+  result.push([start, end]);
+  while (i < intervals.length) {
+    result.push(intervals[i++]); // entirely after newInterval
+  }
+
+  return result;
+}
+```
+
+Three linear passes over an already-sorted list keep this O(n) — no sort
+needed, because the input's order is already the invariant being
+preserved.
+
+## Picking the right sort key: the general lesson
+
+<table>
+  <thead>
+    <tr>
+      <th>Question</th>
+      <th>Sort by</th>
+      <th>Scan rule</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Merge all overlaps</td>
+      <td>Start time</td>
+      <td>Extend current group if next start ≤ current end</td>
+    </tr>
+    <tr>
+      <td>Any conflict at all?</td>
+      <td>Start time</td>
+      <td>Fail if next start &lt; previous end</td>
+    </tr>
+    <tr>
+      <td>Max non-overlapping subset</td>
+      <td>End time</td>
+      <td>Keep if start ≥ last kept end</td>
+    </tr>
+  </tbody>
+</table>
+
+The pattern across all of interval scheduling: identify what "conflict"
+means for the specific question, then choose the sort key that turns the
+greedy first choice into a provably safe one. Getting that key wrong is
+the most common bug in this whole family — the code still runs, it just
+returns a plausible-looking wrong answer.
+
+## Where it shows up
+
+- **Calendar apps** — "find a free slot," "does this booking conflict,"
+  "merge my availability across calendars" are all this pattern.
+- **CPU/resource scheduling** — the maximum non-overlapping subset is
+  literally "activity selection," a classic OS scheduling problem.
+- **Genomics and log analysis** — merging overlapping read ranges or log
+  time windows before further processing.
+
+## Wrap-up
+
+Interval problems look combinatorial but collapse into a single
+sort-then-linear-scan pattern once you sort by the right field: start time
+for merging and conflict detection, end time for maximizing a
+non-overlapping subset. The sort is what turns an O(n²) all-pairs
+comparison into an O(n log n) one, and picking the correct sort key is
+what turns a greedy guess into a provably optimal algorithm.

--- a/src/app/blog/posts/segment-trees-range-queries.mdx
+++ b/src/app/blog/posts/segment-trees-range-queries.mdx
@@ -1,0 +1,174 @@
+---
+title: "Segment Trees: Range Queries in O(log n)"
+publishedAt: "2026-07-14"
+summary: "When an array changes and you still need fast range sum, min, or max queries, prefix sums stop working. Segment trees answer both range queries and point updates in logarithmic time."
+tags: "DSA"
+---
+
+Given an array, "what's the sum of elements from index 3 to 7?" is easy
+with a prefix-sum array — O(1) per query after O(n) preprocessing. The
+catch: prefix sums assume the array never changes. The moment updates
+enter the picture — "add 5 to index 4, now answer more range queries" —
+prefix sums fall apart, because a single update forces recomputing every
+prefix after it, O(n) per update. A **segment tree** answers both range
+queries and point updates in O(log n), by paying a little extra on the
+query side to gain a lot on the update side.
+
+## The structure: a binary tree over ranges
+
+A segment tree is a binary tree built over the array where each node
+covers a **contiguous range** and stores an aggregate (sum, min, max —
+anything associative) over that range. The root covers the whole array;
+each node splits its range in half between its two children; leaves cover
+single elements.
+
+```javascript
+class SegmentTree {
+  constructor(arr) {
+    this.n = arr.length;
+    this.tree = new Array(4 * this.n).fill(0); // safe upper bound
+    this.#build(arr, 1, 0, this.n - 1);
+  }
+
+  #build(arr, node, start, end) {
+    if (start === end) {
+      this.tree[node] = arr[start];
+      return;
+    }
+    const mid = (start + end) >> 1;
+    this.#build(arr, 2 * node, start, mid);
+    this.#build(arr, 2 * node + 1, mid + 1, end);
+    this.tree[node] = this.tree[2 * node] + this.tree[2 * node + 1];
+  }
+}
+```
+
+The `4 * n` sizing is the standard conservative bound for an array-backed
+binary tree that isn't guaranteed to be perfectly balanced at every level;
+it's wasteful but simple, and the constant factor rarely matters in
+practice.
+
+## Range query: descend and combine
+
+To query `[l, r]`, walk the tree from the root. At each node:
+
+- If the node's range is **entirely inside** `[l, r]`, its stored
+  aggregate is exactly what's needed — return it without descending
+  further.
+- If the node's range is **entirely outside** `[l, r]`, it contributes
+  nothing — return the identity value (0 for sum, `Infinity` for min).
+- Otherwise the ranges **partially overlap** — recurse into both children
+  and combine.
+
+```javascript
+query(l, r) {
+  return this.#query(1, 0, this.n - 1, l, r);
+}
+
+#query(node, start, end, l, r) {
+  if (r < start || end < l) return 0;               // no overlap
+  if (l <= start && end <= r) return this.tree[node]; // total overlap
+  const mid = (start + end) >> 1;                     // partial overlap
+  return (
+    this.#query(2 * node, start, mid, l, r) +
+    this.#query(2 * node + 1, mid + 1, end, l, r)
+  );
+}
+```
+
+The key insight for the O(log n) bound: any query range decomposes into
+**at most O(log n) fully-covered nodes**, because as you descend, a range
+that partially overlaps a node stops partially overlapping at most two of
+its children (one on each boundary) — everything else in between is
+either fully in or fully out. That bounds the number of nodes visited per
+level to a small constant, and there are O(log n) levels.
+
+## Point update: fix one leaf, patch the path
+
+Updating index `i` only requires walking straight down to that leaf and
+recomputing the aggregate on the way back up — every node touched sits on
+one root-to-leaf path, which is O(log n) nodes.
+
+```javascript
+update(i, value) {
+  this.#update(1, 0, this.n - 1, i, value);
+}
+
+#update(node, start, end, i, value) {
+  if (start === end) {
+    this.tree[node] = value;
+    return;
+  }
+  const mid = (start + end) >> 1;
+  if (i <= mid) this.#update(2 * node, start, mid, i, value);
+  else this.#update(2 * node + 1, mid + 1, end, i, value);
+  this.tree[node] = this.tree[2 * node] + this.tree[2 * node + 1]; // repair on the way back up
+}
+```
+
+## Choosing the right root-to-leaf trade-off
+
+<table>
+  <thead>
+    <tr>
+      <th>Structure</th>
+      <th>Point update</th>
+      <th>Range query</th>
+      <th>Build</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Plain array</td>
+      <td>O(1)</td>
+      <td>O(n)</td>
+      <td>O(n)</td>
+    </tr>
+    <tr>
+      <td>Prefix sum array</td>
+      <td>O(n)</td>
+      <td>O(1)</td>
+      <td>O(n)</td>
+    </tr>
+    <tr>
+      <td>Segment tree</td>
+      <td>O(log n)</td>
+      <td>O(log n)</td>
+      <td>O(n)</td>
+    </tr>
+    <tr>
+      <td>Fenwick tree (BIT)</td>
+      <td>O(log n)</td>
+      <td>O(log n), sum only</td>
+      <td>O(n log n) naive</td>
+    </tr>
+  </tbody>
+</table>
+
+A **Fenwick tree** (Binary Indexed Tree) gets the same asymptotics for
+prefix-sum-style queries with a much smaller constant factor and a
+one-array implementation — reach for it when the aggregate is a sum and
+the query is always a prefix or difference of prefixes. Segment trees earn
+their extra bulk when the aggregate isn't a simple sum (min, max, GCD),
+when queries are arbitrary ranges rather than prefixes, or when you need
+**range updates** (lazy propagation extends a segment tree to update a
+whole range in O(log n) by deferring the write to children until they're
+actually queried).
+
+## Where it shows up
+
+- **Competitive programming**, constantly — "range sum with updates" and
+  its variants (range min, range max, range GCD) are a staple pattern.
+- **Interval scheduling and calendar systems** — checking "is this whole
+  time range free?" is a range-min query over a busy/free array.
+- **Computational geometry** — sweep-line algorithms use segment trees to
+  track which intervals are currently "active" as the sweep progresses.
+
+## Wrap-up
+
+Prefix sums win when the array is static; a segment tree wins the moment
+updates enter the picture, by organizing the array into a binary tree of
+overlapping ranges where any query decomposes into O(log n) precomputed
+pieces and any update only touches one root-to-leaf path. That symmetric
+O(log n) for both operations — instead of choosing which one to make
+O(1) at the other's expense — is the entire reason the structure exists.

--- a/src/app/blog/posts/weakmap-and-weakset.mdx
+++ b/src/app/blog/posts/weakmap-and-weakset.mdx
@@ -1,0 +1,195 @@
+---
+title: "WeakMap and WeakSet: Memory-Safe References in JavaScript"
+publishedAt: "2026-07-17"
+summary: "A regular Map keeps its keys alive forever, which turns 'metadata keyed by object' into a memory leak. WeakMap holds weak references instead, letting the garbage collector reclaim entries the rest of the program has already forgotten."
+tags: "JavaScript"
+---
+
+Attach some metadata to a DOM node, or cache a computed value keyed by an
+object, and a regular `Map` seems like the obvious tool. It has a hidden
+cost: a `Map` holds a **strong reference** to every key, which means as
+long as the map exists, none of its keys can ever be garbage collected —
+even after every other part of the program has stopped using them. On a
+long-lived map, that's a slow, silent memory leak. `WeakMap` (and its
+sibling `WeakSet`) exist specifically to avoid it.
+
+## Strong references: why a plain Map leaks
+
+```javascript
+const cache = new Map();
+
+function attachMetadata(el) {
+  cache.set(el, { clickCount: 0 });
+}
+
+let button = document.createElement("button");
+attachMetadata(button);
+
+button = null; // the only other reference to this element is gone...
+// ...but cache.get(button) is still holding it alive. The DOM node
+// and its metadata object can never be garbage collected while
+// `cache` exists, no matter how long the page stays open.
+```
+
+Every entry added to `cache` stays there until explicitly deleted. If the
+lifetime of the keys is tied to something transient — DOM nodes that get
+removed, request-scoped objects, component instances that unmount — the
+map keeps growing indefinitely unless you remember to clean up every
+entry by hand.
+
+## WeakMap: keys the garbage collector can still reclaim
+
+`WeakMap` holds its keys **weakly**: a key being in a `WeakMap` does not
+prevent it from being garbage collected. Once nothing else in the program
+references that key, the engine is free to reclaim it — and the
+`WeakMap` entry disappears along with it, automatically, with no cleanup
+code required.
+
+```javascript
+const cache = new WeakMap();
+
+function attachMetadata(el) {
+  cache.set(el, { clickCount: 0 });
+}
+
+let button = document.createElement("button");
+attachMetadata(button);
+
+button = null; // now nothing else references the element...
+// ...so it (and its WeakMap entry) becomes eligible for garbage
+// collection. No leak, no manual cleanup.
+```
+
+Same API shape as `Map` for `get`/`set`/`has`/`delete`, but with
+constraints that follow directly from the weak-reference guarantee:
+
+- **Keys must be objects** (or, as of recent JS, registered `Symbol`s) —
+  primitives like strings and numbers can't be weakly referenced, since
+  they're not tracked by identity.
+- **Not iterable** — no `.keys()`, `.values()`, `.entries()`, no `size`.
+  If the collection *were* enumerable, iterating it would itself be a
+  reference keeping every key alive, defeating the purpose. This is a
+  deliberate API restriction, not a missing feature.
+
+## WeakSet: the same idea for a set of objects
+
+`WeakSet` is to `Set` what `WeakMap` is to `Map` — weakly-held object
+membership, useful for "have I already processed this object?"-style
+tracking that shouldn't itself keep the object alive:
+
+```javascript
+const processed = new WeakSet();
+
+function process(obj) {
+  if (processed.has(obj)) return; // already handled
+  processed.add(obj);
+  // ... do work ...
+}
+```
+
+Once `obj` is no longer referenced anywhere else, it's collected and
+silently drops out of `processed` — there's no way to leak memory by
+forgetting to remove entries, because there's no removal to forget.
+
+## When to reach for the weak version
+
+<table>
+  <thead>
+    <tr>
+      <th>Use case</th>
+      <th>Map/Set</th>
+      <th>WeakMap/WeakSet</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Metadata attached to DOM nodes or object instances</td>
+      <td>Leaks if nodes are removed</td>
+      <td>Auto-cleans when the node is gone</td>
+    </tr>
+    <tr>
+      <td>Private fields (pre-<code>#field</code> syntax pattern)</td>
+      <td>Not private — enumerable</td>
+      <td>Genuinely inaccessible outside the module</td>
+    </tr>
+    <tr>
+      <td>Need to iterate all entries</td>
+      <td>Yes</td>
+      <td>Not possible — use Map</td>
+    </tr>
+    <tr>
+      <td>Keys are primitives (strings, numbers)</td>
+      <td>Yes</td>
+      <td>Not allowed — use Map</td>
+    </tr>
+    <tr>
+      <td>Memoizing a pure function keyed by object argument</td>
+      <td>Leaks the arguments forever</td>
+      <td>Cache entry dies with the argument</td>
+    </tr>
+  </tbody>
+</table>
+
+## A concrete pattern: object-keyed memoization
+
+A memoization cache keyed by object identity is the textbook `WeakMap`
+use case — it should never be the reason an argument object outlives its
+natural lifetime:
+
+```javascript
+const memoCache = new WeakMap();
+
+function expensiveComputation(configObject) {
+  if (memoCache.has(configObject)) {
+    return memoCache.get(configObject);
+  }
+  const result = /* ... heavy work using configObject ... */ compute(configObject);
+  memoCache.set(configObject, result);
+  return result;
+}
+```
+
+If `configObject` is created fresh per request and discarded afterward, a
+regular `Map` here would mean the cache — and every config object ever
+passed in — lives for the lifetime of the process. `WeakMap` makes the
+cache lifetime automatically match the argument's lifetime instead.
+
+## Private state before class private fields
+
+Before `#privateField` syntax existed, `WeakMap` was the standard
+technique for genuinely private instance state — external code has no
+handle to the map, so there's no way to read or enumerate the "private"
+data at all:
+
+```javascript
+const _private = new WeakMap();
+
+class Counter {
+  constructor() {
+    _private.set(this, { count: 0 });
+  }
+  increment() {
+    _private.get(this).count++;
+  }
+  get value() {
+    return _private.get(this).count;
+  }
+}
+```
+
+Modern code should generally prefer `#count` class fields for this — it's
+built-in syntax with the same privacy guarantee and none of the
+boilerplate — but the pattern explains itself once you understand *why*
+`WeakMap` was chosen: an instance's private state should not outlive the
+instance.
+
+## Wrap-up
+
+A regular `Map` or `Set` holds strong references to its keys, so anything
+used as a key is guaranteed to survive as long as the collection does —
+exactly wrong when the collection's job is to attach transient metadata to
+objects with their own independent lifetime. `WeakMap` and `WeakSet` hold
+their entries weakly, letting the garbage collector reclaim a key (and its
+associated entry) the moment nothing else references it, at the cost of
+losing iteration — a trade that's usually exactly what you want for
+caches, metadata, and private state tied to an object's lifetime.

--- a/src/app/dsa/curriculum.ts
+++ b/src/app/dsa/curriculum.ts
@@ -106,17 +106,17 @@ export const curriculum: CurriculumPhase[] = [
         note: 'A hash map and a doubly linked list working together for O(1) everything — a capstone for phases 1–3.',
       },
       {
-        title: 'Backtracking and pruning',
+        slug: 'backtracking-explained',
         difficulty: 'Advanced',
         note: 'Systematic search over choice trees: permutations, subsets, and constraint problems.',
       },
       {
-        title: 'Union-Find (disjoint sets)',
+        slug: 'union-find-disjoint-set',
         difficulty: 'Advanced',
         note: 'Near-constant-time connectivity queries, and the trick behind Kruskal’s algorithm.',
       },
       {
-        title: 'Shortest paths: Dijkstra and friends',
+        slug: 'dijkstra-shortest-paths',
         difficulty: 'Advanced',
         note: 'Weighted graphs — where BFS stops working and priority queues take over.',
       },


### PR DESCRIPTION
## Summary

- Adds 16 new MDX posts, matching the site's existing frontmatter schema and prose style (intro hook, `##` sections, code blocks, comparison tables, `## Wrap-up`):
  - **DSA**: Bloom Filters, Segment Trees, Dijkstra's Algorithm, Merge Intervals & Greedy Scheduling, KMP String Matching
  - **JavaScript**: Async/Await Under the Hood, Proxy and Reflect, WeakMap and WeakSet, Currying and Function Composition, Symbols and Well-Known Symbols, Reimplementing map/filter/reduce
  - **TypeScript** (new tag on the site): Structural Typing, Generics, Discriminated Unions & Exhaustiveness Checking
  - **System Design**: Caching Strategies (cache-aside/write-through/write-back), CAP Theorem & Eventual Consistency
- Wires the new Dijkstra post into the `/dsa` structured curriculum's "Shortest paths" slot, and fixes two stale curriculum placeholders (`backtracking-explained`, `union-find-disjoint-set`) that already had published posts but were never linked to them.

## Test plan

- [x] `yarn build` completes and statically generates all 60 pages, including all 16 new posts
- [x] Fixed a pre-existing landmine in `createHeading`'s `slugify()` (expects a plain string) by removing inline code/emphasis markup from post headings — verified via `yarn start` that all new post pages return 200 and heading anchors render correctly
- [x] Confirmed `sugar-high` highlights TypeScript syntax (interfaces, generics) correctly, same as JS
- [x] Spot-checked `/blog`, `/blog?tag=TypeScript`, `/dsa`, `/rss`, and `/sitemap.xml` all return 200 with the new posts included
