### PR TITLE
Add pattern-wise DSA practice questions page at /dsa/patterns

### DIFF
--- a/src/app/components/pattern-question-list.tsx
+++ b/src/app/components/pattern-question-list.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+export type QuestionItem = {
+  slug: string
+  title: string
+  difficulty: 'Easy' | 'Medium' | 'Hard'
+  summary: string
+  leetcode?: string
+  gfg?: string
+}
+
+export type PracticeItem = {
+  title: string
+  difficulty: 'Easy' | 'Medium' | 'Hard'
+  url: string
+  source: 'LeetCode' | 'GFG'
+}
+
+export type PatternGroup = {
+  slug: string
+  name: string
+  description: string
+  spotIt: string
+  questions: QuestionItem[]
+  practice: PracticeItem[]
+}
+
+const STORAGE_KEY = 'dsa-patterns-progress'
+
+const difficultyStyles: Record<QuestionItem['difficulty'], string> = {
+  Easy: 'text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/60',
+  Medium:
+    'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/60',
+  Hard: 'text-rose-700 dark:text-rose-400 bg-rose-50 dark:bg-rose-950/60',
+}
+
+function loadProgress(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw)
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((s) => typeof s === 'string') : []
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+export function PatternQuestionList({ groups }: { groups: PatternGroup[] }) {
+  const [done, setDone] = useState<Set<string>>(new Set())
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setDone(loadProgress())
+    setHydrated(true)
+  }, [])
+
+  const allSlugs = groups.flatMap((g) => g.questions.map((q) => q.slug))
+  const completedCount = allSlugs.filter((slug) => done.has(slug)).length
+  const percent =
+    allSlugs.length === 0
+      ? 0
+      : Math.round((completedCount / allSlugs.length) * 100)
+
+  function toggle(slug: string) {
+    setDone((prev) => {
+      const next = new Set(prev)
+      if (next.has(slug)) {
+        next.delete(slug)
+      } else {
+        next.add(slug)
+      }
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(next)))
+      } catch {
+        // storage unavailable (private mode, etc.) — progress just won't persist
+      }
+      return next
+    })
+  }
+
+  function reset() {
+    setDone(new Set())
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {}
+  }
+
+  return (
+    <div>
+      <div className="mb-10 rounded-xl border border-neutral-100 dark:border-neutral-800 p-4">
+        <div className="flex items-baseline justify-between gap-4">
+          <p className="text-sm text-neutral-600 dark:text-neutral-300">
+            <span className="font-medium text-neutral-900 dark:text-neutral-50 tabular-nums">
+              {hydrated ? completedCount : 0}
+            </span>{' '}
+            of {allSlugs.length} questions solved
+          </p>
+          {hydrated && completedCount > 0 && (
+            <button
+              onClick={reset}
+              className="text-xs text-neutral-400 dark:text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            >
+              Reset progress
+            </button>
+          )}
+        </div>
+        <div className="mt-3 h-1.5 rounded-full bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-green-600 dark:bg-green-500 transition-all duration-300"
+            style={{ width: `${hydrated ? percent : 0}%` }}
+          />
+        </div>
+        <p className="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
+          Progress is saved in your browser.
+        </p>
+      </div>
+
+      <div className="space-y-12">
+        {groups.map((group, groupIndex) => (
+          <section key={group.slug} id={group.slug} className="scroll-mt-8">
+            <div className="mb-1 flex items-baseline gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800 text-xs font-medium text-neutral-600 dark:text-neutral-300 tabular-nums">
+                {groupIndex + 1}
+              </span>
+              <div>
+                <h2 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+                  {group.name}
+                </h2>
+                <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+                  {group.description}
+                </p>
+                <p className="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
+                  <span className="font-medium text-neutral-500 dark:text-neutral-400">
+                    How to spot it:
+                  </span>{' '}
+                  {group.spotIt}
+                </p>
+              </div>
+            </div>
+
+            <ol className="ml-3 mt-4 border-l border-neutral-100 dark:border-neutral-800 space-y-1">
+              {group.questions.map((q) => {
+                const isDone = hydrated && done.has(q.slug)
+                return (
+                  <li key={q.slug} className="relative pl-6">
+                    <span
+                      className={[
+                        'absolute -left-[5px] top-5 h-[9px] w-[9px] rounded-full border-2 border-white dark:border-neutral-950',
+                        isDone
+                          ? 'bg-green-600 dark:bg-green-500'
+                          : 'bg-neutral-200 dark:bg-neutral-700',
+                      ].join(' ')}
+                    />
+                    <div className="group flex items-start gap-3 rounded-lg py-3 px-3 -mx-3 hover:bg-neutral-50 dark:hover:bg-neutral-900/50 transition-colors">
+                      <button
+                        onClick={() => toggle(q.slug)}
+                        aria-label={
+                          isDone
+                            ? `Mark "${q.title}" as unsolved`
+                            : `Mark "${q.title}" as solved`
+                        }
+                        aria-pressed={isDone}
+                        className={[
+                          'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border transition-colors',
+                          isDone
+                            ? 'border-green-600 dark:border-green-500 bg-green-600 dark:bg-green-500 text-white'
+                            : 'border-neutral-300 dark:border-neutral-600 text-transparent hover:border-green-600 dark:hover:border-green-500',
+                        ].join(' ')}
+                      >
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 12 12"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M2.5 6.5L5 9L9.5 3.5"
+                            stroke="currentColor"
+                            strokeWidth="1.8"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </button>
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                          <Link
+                            href={`/dsa/patterns/${q.slug}`}
+                            className={[
+                              'font-medium transition-colors',
+                              isDone
+                                ? 'text-neutral-400 dark:text-neutral-500 line-through decoration-neutral-300 dark:decoration-neutral-600'
+                                : 'text-neutral-800 dark:text-neutral-200 group-hover:text-green-600 dark:group-hover:text-green-400',
+                            ].join(' ')}
+                          >
+                            {q.title}
+                          </Link>
+                          <span
+                            className={[
+                              'rounded px-1.5 py-0.5 text-[10px] font-medium',
+                              difficultyStyles[q.difficulty],
+                            ].join(' ')}
+                          >
+                            {q.difficulty}
+                          </span>
+                          {q.leetcode && (
+                            <a
+                              href={q.leetcode}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-xs text-neutral-400 dark:text-neutral-500 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+                            >
+                              LeetCode ↗
+                            </a>
+                          )}
+                          {q.gfg && (
+                            <a
+                              href={q.gfg}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-xs text-neutral-400 dark:text-neutral-500 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+                            >
+                              GFG ↗
+                            </a>
+                          )}
+                        </div>
+                        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+                          {q.summary}
+                        </p>
+                      </div>
+                    </div>
+                  </li>
+                )
+              })}
+            </ol>
+
+            {group.practice.length > 0 && (
+              <div className="ml-9 mt-2">
+                <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wide">
+                  More practice
+                </p>
+                <ul className="mt-2 flex flex-wrap gap-2">
+                  {group.practice.map((p) => (
+                    <li key={p.url}>
+                      <a
+                        href={p.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 rounded-md border border-neutral-100 dark:border-neutral-800 px-2 py-1 text-xs text-neutral-600 dark:text-neutral-300 hover:border-green-600/40 dark:hover:border-green-500/40 hover:text-green-700 dark:hover:text-green-400 transition-colors"
+                      >
+                        {p.title}
+                        <span
+                          className={[
+                            'rounded px-1 py-px text-[9px] font-medium',
+                            difficultyStyles[p.difficulty],
+                          ].join(' ')}
+                        >
+                          {p.difficulty}
+                        </span>
+                        <span className="text-neutral-300 dark:text-neutral-600">
+                          {p.source} ↗
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/question-solved-button.tsx
+++ b/src/app/components/question-solved-button.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'dsa-patterns-progress'
+
+function loadProgress(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw)
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((s) => typeof s === 'string') : []
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+export function QuestionSolvedButton({ slug }: { slug: string }) {
+  const [solved, setSolved] = useState(false)
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setSolved(loadProgress().has(slug))
+    setHydrated(true)
+  }, [slug])
+
+  function toggle() {
+    const progress = loadProgress()
+    if (progress.has(slug)) {
+      progress.delete(slug)
+    } else {
+      progress.add(slug)
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(progress)))
+    } catch {
+      // storage unavailable — state still toggles for this visit
+    }
+    setSolved(progress.has(slug))
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      aria-pressed={solved}
+      className={[
+        'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors',
+        hydrated && solved
+          ? 'border-green-600 dark:border-green-500 bg-green-600 dark:bg-green-500 text-white'
+          : 'border-neutral-200 dark:border-neutral-700 text-neutral-500 dark:text-neutral-400 hover:border-green-600 dark:hover:border-green-500 hover:text-green-700 dark:hover:text-green-400',
+      ].join(' ')}
+    >
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path
+          d="M2.5 6.5L5 9L9.5 3.5"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      {hydrated && solved ? 'Solved' : 'Mark as solved'}
+    </button>
+  )
+}

--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { getBlogPosts, getReadingTime } from '@/app/blog/utils'
 import { DsaPath, type PathPhase } from '@/app/components/dsa-path'
 import { baseUrl } from '@/app/sitemap'
@@ -57,6 +58,26 @@ export default function Page() {
         or jump to whatever you want to brush up on. Most posts include
         interactive visualizations you can step through.
       </p>
+      <Link
+        href="/dsa/patterns"
+        className="group mb-10 flex items-center justify-between gap-4 rounded-xl border border-neutral-100 dark:border-neutral-800 p-4 hover:border-green-600/40 dark:hover:border-green-500/40 transition-colors"
+      >
+        <div>
+          <p className="font-medium text-neutral-900 dark:text-neutral-50 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors">
+            Practice: pattern-wise questions
+          </p>
+          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+            Curated LeetCode and GFG questions grouped by pattern — each one
+            explained with examples, multiple approaches, and a dry run.
+          </p>
+        </div>
+        <span
+          aria-hidden="true"
+          className="text-neutral-300 dark:text-neutral-600 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors"
+        >
+          →
+        </span>
+      </Link>
       <DsaPath phases={phases} />
     </section>
   )

--- a/src/app/dsa/patterns/[slug]/page.tsx
+++ b/src/app/dsa/patterns/[slug]/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { CustomMDX } from '@/app/components/mdx'
+import { QuestionSolvedButton } from '@/app/components/question-solved-button'
+import { baseUrl } from '@/app/sitemap'
+import { patterns } from '../patterns'
+import { getPatternQuestions, type QuestionDifficulty } from '../utils'
+
+const difficultyStyles: Record<QuestionDifficulty, string> = {
+  Easy: 'text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/60',
+  Medium:
+    'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/60',
+  Hard: 'text-rose-700 dark:text-rose-400 bg-rose-50 dark:bg-rose-950/60',
+}
+
+export async function generateStaticParams() {
+  return getPatternQuestions().map((question) => ({ slug: question.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const question = getPatternQuestions().find((q) => q.slug === slug)
+  if (!question) return
+
+  const { title, summary: description } = question.metadata
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent(title)}`
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/dsa/patterns/${question.slug}`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `${baseUrl}/dsa/patterns/${question.slug}`,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+  }
+}
+
+export default async function Question({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const questions = getPatternQuestions()
+  const question = questions.find((q) => q.slug === slug)
+
+  if (!question) notFound()
+
+  const pattern = patterns.find((p) => p.slug === question.metadata.pattern)
+  const siblings = questions.filter(
+    (q) => q.metadata.pattern === question.metadata.pattern
+  )
+  const index = siblings.findIndex((q) => q.slug === slug)
+  const prev = index > 0 ? siblings[index - 1] : undefined
+  const next = index < siblings.length - 1 ? siblings[index + 1] : undefined
+
+  return (
+    <section>
+      <div className="mb-10 pb-8 border-b border-neutral-100 dark:border-neutral-800">
+        <Link
+          href={`/dsa/patterns#${question.metadata.pattern}`}
+          className="text-xs text-neutral-400 dark:text-neutral-500 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+        >
+          ← DSA Patterns{pattern ? ` / ${pattern.name}` : ''}
+        </Link>
+        <h1 className="title mt-3 font-semibold text-2xl tracking-tight text-neutral-900 dark:text-neutral-50 mb-3">
+          {question.metadata.title}
+        </h1>
+        <div className="flex flex-wrap items-center gap-3">
+          <span
+            className={[
+              'rounded px-1.5 py-0.5 text-[10px] font-medium',
+              difficultyStyles[question.metadata.difficulty],
+            ].join(' ')}
+          >
+            {question.metadata.difficulty}
+          </span>
+          {question.metadata.leetcode && (
+            <a
+              href={question.metadata.leetcode}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-neutral-500 dark:text-neutral-400 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+            >
+              Solve on LeetCode ↗
+            </a>
+          )}
+          {question.metadata.gfg && (
+            <a
+              href={question.metadata.gfg}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-neutral-500 dark:text-neutral-400 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+            >
+              Solve on GFG ↗
+            </a>
+          )}
+          <QuestionSolvedButton slug={question.slug} />
+        </div>
+      </div>
+
+      <article className="prose">
+        {/* blockJS: false lets trusted repo-authored MDX pass object props
+            (e.g. <Table data={...}>); blockDangerousJS stays on by default */}
+        <CustomMDX source={question.content} options={{ blockJS: false }} />
+      </article>
+
+      <nav className="mt-12 flex items-start justify-between gap-4 border-t border-neutral-100 dark:border-neutral-800 pt-6 text-sm">
+        {prev ? (
+          <Link
+            href={`/dsa/patterns/${prev.slug}`}
+            className="text-neutral-500 dark:text-neutral-400 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+          >
+            ← {prev.metadata.title}
+          </Link>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <Link
+            href={`/dsa/patterns/${next.slug}`}
+            className="text-right text-neutral-500 dark:text-neutral-400 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+          >
+            {next.metadata.title} →
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </section>
+  )
+}

--- a/src/app/dsa/patterns/page.tsx
+++ b/src/app/dsa/patterns/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link'
+import {
+  PatternQuestionList,
+  type PatternGroup,
+} from '@/app/components/pattern-question-list'
+import { baseUrl } from '@/app/sitemap'
+import { patterns } from './patterns'
+import { getPatternQuestions } from './utils'
+
+export const metadata = {
+  title: 'DSA Patterns',
+  description:
+    'Pattern-wise DSA practice questions with LeetCode and GFG links — each solved question explained with examples, multiple approaches, and a step-by-step dry run.',
+  openGraph: {
+    title: 'DSA Patterns',
+    description:
+      'Pattern-wise DSA practice questions with LeetCode and GFG links, multiple approaches, and dry runs.',
+    url: `${baseUrl}/dsa/patterns`,
+    images: [{ url: `/og?title=${encodeURIComponent('DSA Patterns')}` }],
+  },
+}
+
+export default function Page() {
+  const questions = getPatternQuestions()
+
+  const groups: PatternGroup[] = patterns.map((pattern) => ({
+    slug: pattern.slug,
+    name: pattern.name,
+    description: pattern.description,
+    spotIt: pattern.spotIt,
+    questions: questions
+      .filter((q) => q.metadata.pattern === pattern.slug)
+      .map((q) => ({
+        slug: q.slug,
+        title: q.metadata.title,
+        difficulty: q.metadata.difficulty,
+        summary: q.metadata.summary,
+        leetcode: q.metadata.leetcode,
+        gfg: q.metadata.gfg,
+      })),
+    practice: pattern.practice,
+  }))
+
+  return (
+    <section>
+      <h1 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
+        DSA Patterns
+      </h1>
+      <p className="mb-4 text-sm text-neutral-500 dark:text-neutral-400">
+        Most interview questions are variations of a small set of patterns.
+        Each pattern below has fully worked questions — the problem explained
+        with an example, more than one approach, and a dry run of the solution
+        — plus extra practice links on LeetCode and GeeksforGeeks.
+      </p>
+      <p className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+        Reading up on the concepts first? Follow the{' '}
+        <Link
+          href="/dsa"
+          className="text-green-600 dark:text-green-400 hover:underline underline-offset-2"
+        >
+          Learn DSA path
+        </Link>{' '}
+        — it covers the theory behind these patterns in order.
+      </p>
+      <PatternQuestionList groups={groups} />
+    </section>
+  )
+}

--- a/src/app/dsa/patterns/patterns.ts
+++ b/src/app/dsa/patterns/patterns.ts
@@ -1,0 +1,419 @@
+export type PracticeLink = {
+  title: string
+  difficulty: 'Easy' | 'Medium' | 'Hard'
+  url: string
+  source: 'LeetCode' | 'GFG'
+}
+
+export type Pattern = {
+  slug: string
+  name: string
+  description: string
+  spotIt: string
+  practice: PracticeLink[]
+}
+
+export const patterns: Pattern[] = [
+  {
+    slug: 'two-pointers',
+    name: 'Two Pointers',
+    description:
+      'Walk two indexes toward each other (or in the same direction) instead of checking every pair — turns many O(n²) array problems into O(n).',
+    spotIt:
+      'Sorted array or string, and the question asks about pairs, triplets, or removing/comparing elements from both ends.',
+    practice: [
+      {
+        title: 'Container With Most Water',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/container-with-most-water/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Remove Duplicates from Sorted Array',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/remove-duplicates-from-sorted-array/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Valid Palindrome',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/valid-palindrome/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Trapping Rain Water',
+        difficulty: 'Hard',
+        url: 'https://leetcode.com/problems/trapping-rain-water/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'sliding-window',
+    name: 'Sliding Window',
+    description:
+      'Maintain a window over a contiguous run of elements and slide it forward, updating state incrementally instead of recomputing from scratch.',
+    spotIt:
+      'The words “subarray”, “substring”, or “contiguous” appear, and you need a longest / shortest / max-sum window that satisfies a condition.',
+    practice: [
+      {
+        title: 'Minimum Size Subarray Sum',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/minimum-size-subarray-sum/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Longest Repeating Character Replacement',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/longest-repeating-character-replacement/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Permutation in String',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/permutation-in-string/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Minimum Window Substring',
+        difficulty: 'Hard',
+        url: 'https://leetcode.com/problems/minimum-window-substring/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'fast-slow-pointers',
+    name: 'Fast & Slow Pointers',
+    description:
+      'Two pointers moving at different speeds through a sequence — if there is a cycle they must eventually meet, and when the fast one finishes, the slow one is at the middle.',
+    spotIt:
+      'Linked list problems about cycles or middles, or any process that repeatedly feeds a value back into itself.',
+    practice: [
+      {
+        title: 'Middle of the Linked List',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/middle-of-the-linked-list/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Linked List Cycle II',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/linked-list-cycle-ii/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Palindrome Linked List',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/palindrome-linked-list/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Reorder List',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/reorder-list/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'merge-intervals',
+    name: 'Merge Intervals',
+    description:
+      'Sort intervals by start time, then sweep left to right deciding whether each interval overlaps the previous one — merge, count, or discard as you go.',
+    spotIt:
+      'Input is a list of ranges (meetings, bookings, [start, end] pairs) and the question is about overlap, merging, or how many fit.',
+    practice: [
+      {
+        title: 'Insert Interval',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/insert-interval/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Meeting Rooms (GFG)',
+        difficulty: 'Easy',
+        url: 'https://www.geeksforgeeks.org/dsa/check-if-any-two-intervals-overlap-among-a-given-set-of-intervals/',
+        source: 'GFG',
+      },
+      {
+        title: 'Minimum Number of Arrows to Burst Balloons',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/minimum-number-of-arrows-to-burst-balloons/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'binary-search',
+    name: 'Binary Search',
+    description:
+      'Halve the search space every step. Works on sorted arrays — and, more powerfully, on any monotonic “answer space” where you can ask: is this guess feasible?',
+    spotIt:
+      'Sorted input, O(log n) required, or a “minimum X such that condition holds” question where the condition flips from false to true exactly once.',
+    practice: [
+      {
+        title: 'Search in Rotated Sorted Array',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/search-in-rotated-sorted-array/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Find First and Last Position of Element',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/find-first-and-last-position-of-element-in-sorted-array/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Find Minimum in Rotated Sorted Array',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Capacity to Ship Packages Within D Days',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/capacity-to-ship-packages-within-d-days/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'stack',
+    name: 'Stack & Monotonic Stack',
+    description:
+      'Last-in-first-out matching for nested structure, and the monotonic variant: keep the stack sorted so each element instantly finds its “next greater / smaller” partner.',
+    spotIt:
+      'Matching brackets, undo-like nesting, or “next greater element” / “how long until a warmer day” style questions.',
+    practice: [
+      {
+        title: 'Min Stack',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/min-stack/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Evaluate Reverse Polish Notation',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/evaluate-reverse-polish-notation/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Next Greater Element (GFG)',
+        difficulty: 'Medium',
+        url: 'https://www.geeksforgeeks.org/dsa/next-greater-element/',
+        source: 'GFG',
+      },
+      {
+        title: 'Largest Rectangle in Histogram',
+        difficulty: 'Hard',
+        url: 'https://leetcode.com/problems/largest-rectangle-in-histogram/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'heap-top-k',
+    name: 'Heap / Top-K',
+    description:
+      'A heap always knows its smallest (or largest) element in O(1). Keep a heap of size k while streaming through data to answer “top k” questions without full sorting.',
+    spotIt:
+      'The words “k largest”, “k closest”, “k most frequent”, or a stream where you repeatedly need the current min/max.',
+    practice: [
+      {
+        title: 'Last Stone Weight',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/last-stone-weight/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'K Closest Points to Origin',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/k-closest-points-to-origin/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Kth Smallest Element in a BST',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/kth-smallest-element-in-a-bst/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Find Median from Data Stream',
+        difficulty: 'Hard',
+        url: 'https://leetcode.com/problems/find-median-from-data-stream/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'tree-bfs-dfs',
+    name: 'Tree BFS / DFS',
+    description:
+      'Depth-first recursion for structure questions (depth, validity, paths); breadth-first with a queue for anything organized by levels.',
+    spotIt:
+      'Binary tree input. “Level by level” means BFS; “depth”, “path”, or “is it valid” usually means DFS.',
+    practice: [
+      {
+        title: 'Maximum Depth of Binary Tree',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/maximum-depth-of-binary-tree/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Invert Binary Tree',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/invert-binary-tree/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Diameter of Binary Tree',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/diameter-of-binary-tree/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Binary Tree Right Side View',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/binary-tree-right-side-view/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'graphs',
+    name: 'Graph Traversal',
+    description:
+      'BFS/DFS over grids and adjacency lists: flood-fill connected regions, count components, and use topological ordering when tasks have prerequisites.',
+    spotIt:
+      'A grid of cells, a list of edges, or dependency pairs (“course a requires course b”). Count regions, check reachability, or order tasks.',
+    practice: [
+      {
+        title: 'Flood Fill',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/flood-fill/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Rotting Oranges',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/rotting-oranges/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Clone Graph',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/clone-graph/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Pacific Atlantic Water Flow',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/pacific-atlantic-water-flow/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'backtracking',
+    name: 'Backtracking',
+    description:
+      'Build a candidate solution one choice at a time; when a choice can no longer lead to a valid answer, undo it and try the next one. The shape behind subsets, permutations, and puzzles.',
+    spotIt:
+      '“All possible …” — combinations, permutations, subsets, board placements — where you must enumerate rather than count.',
+    practice: [
+      {
+        title: 'Permutations',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/permutations/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Word Search',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/word-search/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Palindrome Partitioning',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/palindrome-partitioning/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'N-Queens',
+        difficulty: 'Hard',
+        url: 'https://leetcode.com/problems/n-queens/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'dynamic-programming',
+    name: 'Dynamic Programming',
+    description:
+      'When a problem breaks into overlapping subproblems, solve each subproblem once and reuse the answer — top-down with memoization or bottom-up with a table.',
+    spotIt:
+      '“How many ways…”, “minimum cost to…”, “longest/shortest …” where today’s answer is built from smaller versions of the same question.',
+    practice: [
+      {
+        title: 'House Robber',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/house-robber/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Longest Increasing Subsequence',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/longest-increasing-subsequence/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Longest Common Subsequence',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/longest-common-subsequence/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Word Break',
+        difficulty: 'Medium',
+        url: 'https://leetcode.com/problems/word-break/',
+        source: 'LeetCode',
+      },
+    ],
+  },
+  {
+    slug: 'math',
+    name: 'Math & Number Theory',
+    description:
+      'A small toolbox — Euclid’s GCD, the sieve of Eratosthenes, fast exponentiation, counting prime factors — that solves a surprising number of interview questions outright.',
+    spotIt:
+      'Primes, divisibility, powers, factorials, digit manipulation — anywhere brute-force arithmetic would overflow or time out.',
+    practice: [
+      {
+        title: 'Palindrome Number',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/palindrome-number/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Sqrt(x)',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/sqrtx/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Happy Number',
+        difficulty: 'Easy',
+        url: 'https://leetcode.com/problems/happy-number/',
+        source: 'LeetCode',
+      },
+      {
+        title: 'Program for LCM of two numbers (GFG)',
+        difficulty: 'Easy',
+        url: 'https://www.geeksforgeeks.org/dsa/program-to-find-lcm-of-two-numbers/',
+        source: 'GFG',
+      },
+    ],
+  },
+]

--- a/src/app/dsa/patterns/questions/binary-search.mdx
+++ b/src/app/dsa/patterns/questions/binary-search.mdx
@@ -1,0 +1,97 @@
+---
+title: "Binary Search"
+pattern: "binary-search"
+order: 501
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/binary-search/"
+gfg: "https://www.geeksforgeeks.org/dsa/binary-search/"
+summary: "The template everything else builds on — get the loop condition, midpoint, and boundary updates right once, and reuse them forever."
+---
+
+## The problem
+
+Given a **sorted** array of distinct integers and a target, return the target's index, or `-1` if it's not present — in O(log n) time.
+
+**Example:** `nums = [-1, 0, 3, 5, 9, 12]`, `target = 9` → answer `4`.
+
+The O(log n) requirement is the giveaway: each comparison must eliminate half the remaining candidates.
+
+## Approach 1 — Linear scan
+
+```js
+function search(nums, target) {
+  for (let i = 0; i < nums.length; i++) {
+    if (nums[i] === target) return i
+  }
+  return -1
+}
+```
+
+**Time:** O(n). Fine for tiny arrays, but it ignores the sorted order entirely — every comparison eliminates just one candidate.
+
+## Approach 2 — Binary search
+
+Keep a window `[lo, hi]` that must contain the target if it exists. Compare the middle element:
+
+- `nums[mid] === target` → found.
+- `nums[mid] < target` → target must be right of mid → `lo = mid + 1`.
+- `nums[mid] > target` → target must be left of mid → `hi = mid - 1`.
+
+```js
+function search(nums, target) {
+  let lo = 0
+  let hi = nums.length - 1
+
+  while (lo <= hi) {
+    const mid = lo + Math.floor((hi - lo) / 2)
+    if (nums[mid] === target) return mid
+    if (nums[mid] < target) lo = mid + 1
+    else hi = mid - 1
+  }
+  return -1
+}
+```
+
+**Time:** O(log n). **Space:** O(1).
+
+Three details carry all the correctness:
+
+1. **`lo <= hi`**, not `lo < hi` — with `<` you'd skip checking the final one-element window.
+2. **`mid ± 1`**, never `mid` — mid has been checked; keeping it in the window can loop forever.
+3. **`lo + (hi - lo) / 2`** — same value as `(lo + hi) / 2` but overflow-safe in fixed-width languages (harmless habit in JavaScript).
+
+## Dry run
+
+`nums = [-1, 0, 3, 5, 9, 12]`, `target = 9`:
+
+<Table
+  data={{
+    headers: ['Step', 'lo', 'hi', 'mid', 'nums[mid]', 'Decision'],
+    rows: [
+      ['1', '0', '5', '2', '3', '3 < 9 → search right half, lo = 3'],
+      ['2', '3', '5', '4', '9', 'Found → return 4'],
+    ],
+  }}
+/>
+
+And a **miss**, `target = 2`:
+
+<Table
+  data={{
+    headers: ['Step', 'lo', 'hi', 'mid', 'nums[mid]', 'Decision'],
+    rows: [
+      ['1', '0', '5', '2', '3', '3 > 2 → hi = 1'],
+      ['2', '0', '1', '0', '-1', '-1 < 2 → lo = 1'],
+      ['3', '1', '1', '1', '0', '0 < 2 → lo = 2'],
+      ['4', '2 > hi = 1', '—', '—', '—', 'Window empty → return -1'],
+    ],
+  }}
+/>
+
+Two to four steps for six elements; a million elements would take at most twenty.
+
+## Edge cases
+
+- Empty array → `hi = -1`, loop never runs, return `-1`.
+- Target smaller/larger than everything → window shrinks off the left/right edge cleanly.
+- Duplicates: this template returns *an* occurrence, not necessarily the first — finding first/last occurrence is the lower/upper-bound variant (LeetCode 34).

--- a/src/app/dsa/patterns/questions/climbing-stairs.mdx
+++ b/src/app/dsa/patterns/questions/climbing-stairs.mdx
@@ -1,0 +1,113 @@
+---
+title: "Climbing Stairs"
+pattern: "dynamic-programming"
+order: 1101
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/climbing-stairs/"
+gfg: "https://www.geeksforgeeks.org/dsa/count-ways-reach-nth-stair/"
+summary: "The gateway DP problem — watch naive recursion explode, then fix it with memoization, a table, and finally two variables."
+---
+
+## The problem
+
+You're climbing a staircase with `n` steps. Each move you climb **1 or 2** steps. How many distinct ways can you reach the top?
+
+**Example:** `n = 4` → answer `5`:
+
+`1+1+1+1`, `1+1+2`, `1+2+1`, `2+1+1`, `2+2`.
+
+The key recurrence: to stand on step `n`, your last move came from step `n-1` (a 1-step) or step `n-2` (a 2-step). Those two groups don't overlap and cover everything, so
+
+`ways(n) = ways(n-1) + ways(n-2)` — Fibonacci in disguise.
+
+## Approach 1 — Plain recursion (exponential)
+
+```js
+function climbStairs(n) {
+  if (n <= 2) return n
+  return climbStairs(n - 1) + climbStairs(n - 2)
+}
+```
+
+**Time:** O(2ⁿ). `climbStairs(5)` computes `climbStairs(3)` twice, `climbStairs(2)` three times — the same subproblems over and over. At n = 45 this takes billions of calls.
+
+That repeated work is the **overlapping subproblems** signal: the moment you spot it, DP applies.
+
+## Approach 2 — Memoization (top-down DP)
+
+Cache each result the first time it's computed.
+
+```js
+function climbStairs(n, memo = new Map()) {
+  if (n <= 2) return n
+  if (memo.has(n)) return memo.get(n)
+  const ways = climbStairs(n - 1, memo) + climbStairs(n - 2, memo)
+  memo.set(n, ways)
+  return ways
+}
+```
+
+**Time:** O(n) — each subproblem solved once. **Space:** O(n) for the cache and recursion stack.
+
+## Approach 3 — Tabulation (bottom-up DP)
+
+Fill an array from the base cases upward — same recurrence, no recursion.
+
+```js
+function climbStairs(n) {
+  if (n <= 2) return n
+  const dp = new Array(n + 1)
+  dp[1] = 1
+  dp[2] = 2
+  for (let i = 3; i <= n; i++) {
+    dp[i] = dp[i - 1] + dp[i - 2]
+  }
+  return dp[n]
+}
+```
+
+**Time:** O(n). **Space:** O(n).
+
+## Approach 4 — Two variables (space-optimized)
+
+`dp[i]` only ever reads the previous two cells, so keep just those.
+
+```js
+function climbStairs(n) {
+  if (n <= 2) return n
+  let prev2 = 1 // ways(1)
+  let prev1 = 2 // ways(2)
+  for (let i = 3; i <= n; i++) {
+    const current = prev1 + prev2
+    prev2 = prev1
+    prev1 = current
+  }
+  return prev1
+}
+```
+
+**Time:** O(n). **Space:** O(1). This four-stage progression — recursion → memo → table → rolling variables — is the standard playbook for most 1-D DP problems.
+
+## Dry run
+
+Approach 4 with `n = 6`:
+
+<Table
+  data={{
+    headers: ['i', 'prev2 (ways i-2)', 'prev1 (ways i-1)', 'current = prev1 + prev2'],
+    rows: [
+      ['3', '1', '2', '3'],
+      ['4', '2', '3', '5'],
+      ['5', '3', '5', '8'],
+      ['6', '5', '8', '13'],
+    ],
+  }}
+/>
+
+`climbStairs(6) = 13`. And the `n = 4` row confirms our hand-count of 5 from the example.
+
+## Edge cases
+
+- `n = 1` → 1, `n = 2` → 2 — both handled by the early return (and note `ways(2) = 2`, not 1: `1+1` and `2`).
+- Results grow like Fibonacci — beyond n ≈ 78 they exceed `Number.MAX_SAFE_INTEGER`; use `BigInt` if the problem's n went that high (LeetCode's doesn't).
+- Same recurrence family: House Robber, Min Cost Climbing Stairs, Fibonacci Number — recognize one, solve them all.

--- a/src/app/dsa/patterns/questions/coin-change.mdx
+++ b/src/app/dsa/patterns/questions/coin-change.mdx
@@ -1,0 +1,93 @@
+---
+title: "Coin Change"
+pattern: "dynamic-programming"
+order: 1102
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/coin-change/"
+gfg: "https://www.geeksforgeeks.org/dsa/coin-change-dp-7/"
+summary: "The problem that teaches why greedy fails and how to build a bottom-up DP table over amounts — plus the unreachable-state trick."
+---
+
+## The problem
+
+Given coin denominations `coins` (unlimited supply of each) and an `amount`, return the **fewest coins** needed to make exactly that amount, or `-1` if it can't be made.
+
+**Example:** `coins = [1, 2, 5]`, `amount = 11` → answer `3` (5 + 5 + 1).
+
+## Approach 1 — Greedy (and why it's wrong)
+
+"Always take the biggest coin that fits" feels right and works for standard currencies:
+
+```js
+// WRONG in general
+function coinChangeGreedy(coins, amount) {
+  coins.sort((a, b) => b - a)
+  let count = 0
+  for (const coin of coins) {
+    count += Math.floor(amount / coin)
+    amount %= coin
+  }
+  return amount === 0 ? count : -1
+}
+```
+
+But take `coins = [1, 3, 4]`, `amount = 6`: greedy grabs 4, then must use 1 + 1 → **3 coins**. The optimum is 3 + 3 → **2 coins**. Greedy commits to a big coin that ruins the remainder — this failure is the motivation for DP.
+
+## Approach 2 — Bottom-up DP over amounts
+
+Define `dp[a]` = fewest coins to make amount `a`. To make `a`, the *last* coin used was some `coin`, leaving a smaller amount:
+
+`dp[a] = 1 + min(dp[a - coin])` over every coin that fits.
+
+Fill from 0 upward; initialize with `Infinity` meaning "not yet reachable".
+
+```js
+function coinChange(coins, amount) {
+  const dp = new Array(amount + 1).fill(Infinity)
+  dp[0] = 0 // zero coins make amount 0
+
+  for (let a = 1; a <= amount; a++) {
+    for (const coin of coins) {
+      if (coin <= a && dp[a - coin] + 1 < dp[a]) {
+        dp[a] = dp[a - coin] + 1
+      }
+    }
+  }
+  return dp[amount] === Infinity ? -1 : dp[amount]
+}
+```
+
+**Time:** O(amount × coins). **Space:** O(amount).
+
+`Infinity` does double duty: it marks unreachable amounts, and `Infinity + 1` is still `Infinity`, so unreachable states never contaminate reachable ones.
+
+## Approach 3 — Top-down memoized recursion
+
+The same recurrence written as recursion with a cache: `best(a) = 1 + min(best(a - coin))`. Identical complexity; sometimes easier to derive under pressure. (BFS over amounts also works — each "level" is one more coin — a fun alternative to mention.)
+
+## Dry run
+
+Approach 2 with the greedy-killer: `coins = [1, 3, 4]`, `amount = 6`.
+
+<Table
+  data={{
+    headers: ['a', 'via coin 1 (dp[a-1]+1)', 'via coin 3 (dp[a-3]+1)', 'via coin 4 (dp[a-4]+1)', 'dp[a]'],
+    rows: [
+      ['1', 'dp[0]+1 = 1', '—', '—', '1'],
+      ['2', 'dp[1]+1 = 2', '—', '—', '2'],
+      ['3', 'dp[2]+1 = 3', 'dp[0]+1 = 1', '—', '1'],
+      ['4', 'dp[3]+1 = 2', 'dp[1]+1 = 2', 'dp[0]+1 = 1', '1'],
+      ['5', 'dp[4]+1 = 2', 'dp[2]+1 = 3', 'dp[1]+1 = 2', '2'],
+      ['6', 'dp[5]+1 = 3', 'dp[3]+1 = 2', 'dp[2]+1 = 3', '2'],
+    ],
+  }}
+/>
+
+`dp[6] = 2` (3 + 3) — the table considers *every* last-coin choice at every amount, which is exactly what greedy refused to do.
+
+## Edge cases
+
+- `amount = 0` → `0` coins (base case, not -1).
+- Amount unreachable, e.g. `coins = [2]`, `amount = 3` → `dp[3]` stays `Infinity` → `-1`.
+- A coin larger than the current amount is skipped by `coin <= a`.
+- Counting *ways* instead of *fewest* (Coin Change II, LC 518) flips the loop order and the recurrence — related, but not the same table.

--- a/src/app/dsa/patterns/questions/combination-sum.mdx
+++ b/src/app/dsa/patterns/questions/combination-sum.mdx
@@ -1,0 +1,89 @@
+---
+title: "Combination Sum"
+pattern: "backtracking"
+order: 1002
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/combination-sum/"
+gfg: "https://www.geeksforgeeks.org/dsa/combinational-sum/"
+summary: "Backtracking with pruning and unlimited reuse — and the start-index trick that kills duplicate combinations."
+---
+
+## The problem
+
+Given distinct positive integers `candidates` and a `target`, return all **unique combinations** where the chosen numbers sum to the target. The same number may be used **unlimited times**. Combinations differing only in order count as the same (so `[2, 3]` and `[3, 2]` are one answer).
+
+**Example:** `candidates = [2, 3, 6, 7]`, `target = 7` → `[[2, 2, 3], [7]]`.
+
+Two wrinkles beyond plain subsets: numbers are reusable, and we must avoid emitting the same multiset in different orders.
+
+## Approach 1 — Naive DFS over all candidates (why it duplicates)
+
+If every recursive call may pick *any* candidate, the paths `2 → 2 → 3`, `2 → 3 → 2`, and `3 → 2 → 2` all reach the same combination — you'd need to sort each result and deduplicate with a set. Wasteful and messy.
+
+The fix is an ordering rule: **each call may only pick candidates at or after its `start` index.** Once you move past a candidate, you never return to it — so every combination is generated exactly once, in non-decreasing candidate order.
+
+## Approach 2 — Backtracking with a start index
+
+```js
+function combinationSum(candidates, target) {
+  candidates.sort((a, b) => a - b) // enables early pruning
+  const result = []
+  const path = []
+
+  function backtrack(start, remaining) {
+    if (remaining === 0) {
+      result.push([...path])
+      return
+    }
+
+    for (let i = start; i < candidates.length; i++) {
+      if (candidates[i] > remaining) break // sorted → everything after is bigger too
+
+      path.push(candidates[i])
+      backtrack(i, remaining - candidates[i]) // i, NOT i + 1 — reuse allowed
+      path.pop()
+    }
+  }
+
+  backtrack(0, target)
+  return result
+}
+```
+
+**Time:** exponential in the worst case (it's an enumeration problem — the output itself can be huge); pruning cuts real workloads dramatically. **Space:** O(target / min(candidates)) recursion depth.
+
+The two indexes to internalize:
+
+- `backtrack(i, ...)` — passing `i` (not `i + 1`) is what allows reusing the same candidate.
+- The loop *starting at* `start` is what prevents `[3, 2, 2]`-style reorderings of `[2, 2, 3]`.
+
+## Dry run
+
+`candidates = [2, 3, 6, 7]`, `target = 7`:
+
+<Table
+  data={{
+    headers: ['path', 'remaining', 'What happens'],
+    rows: [
+      ['[2]', '5', 'try 2 again'],
+      ['[2, 2]', '3', 'try 2 again'],
+      ['[2, 2, 2]', '1', 'every candidate > 1 → prune, pop'],
+      ['[2, 2, 3]', '0', 'FOUND — record, pop'],
+      ['[2, 3]', '2', '3 > 2 → prune (only 3+, since start moved past 2), pop'],
+      ['[2, 6]', '—', '6 > 5 already pruned by break'],
+      ['[3]', '4', 'try 3 again'],
+      ['[3, 3]', '1', 'prune, pop; 6, 7 > 4 → pop'],
+      ['[6]', '1', 'prune, pop'],
+      ['[7]', '0', 'FOUND — record'],
+    ],
+  }}
+/>
+
+Result: `[[2, 2, 3], [7]]`. Notice `[3, 2, 2]` was never even attempted — the start index makes that branch unreachable.
+
+## Edge cases
+
+- `target` smaller than every candidate → `[]`.
+- A candidate equal to the target → single-element combination, found immediately.
+- The guaranteed-positive candidates are what make `remaining` strictly decrease — with zeros or negatives the recursion could never terminate without extra guards.
+- Variant map: Combination Sum II (LC 40) = duplicates in input, each used once → pass `i + 1` and skip equal neighbors; Combination Sum III (LC 216) = fixed count k → add a length check.

--- a/src/app/dsa/patterns/questions/count-primes.mdx
+++ b/src/app/dsa/patterns/questions/count-primes.mdx
@@ -1,0 +1,91 @@
+---
+title: "Count Primes (Sieve of Eratosthenes)"
+pattern: "math"
+order: 1201
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/count-primes/"
+gfg: "https://www.geeksforgeeks.org/dsa/sieve-of-eratosthenes/"
+summary: "Checking each number for primality is too slow — the 2,300-year-old sieve crosses out composites in near-linear time."
+---
+
+## The problem
+
+Count the prime numbers **strictly less than** `n`.
+
+**Example:** `n = 20` → answer `8`. The primes below 20 are 2, 3, 5, 7, 11, 13, 17, 19.
+
+## Approach 1 — Test each number individually
+
+A number `x` is prime if nothing from 2 to `√x` divides it (a divisor pair always has one member at or below the square root).
+
+```js
+function isPrime(x) {
+  if (x < 2) return false
+  for (let d = 2; d * d <= x; d++) {
+    if (x % d === 0) return false
+  }
+  return true
+}
+
+function countPrimes(n) {
+  let count = 0
+  for (let x = 2; x < n; x++) {
+    if (isPrime(x)) count++
+  }
+  return count
+}
+```
+
+**Time:** O(n√n) — with n = 5,000,000 (LeetCode's limit) that's billions of divisions. Too slow.
+
+## Approach 2 — Sieve of Eratosthenes
+
+Flip the direction: instead of asking "is x prime?", let each prime **cross out its own multiples**. What survives is prime.
+
+```js
+function countPrimes(n) {
+  if (n < 3) return 0
+  const isPrime = new Array(n).fill(true)
+  isPrime[0] = isPrime[1] = false
+
+  for (let p = 2; p * p < n; p++) {
+    if (!isPrime[p]) continue
+    for (let multiple = p * p; multiple < n; multiple += p) {
+      isPrime[multiple] = false
+    }
+  }
+  return isPrime.filter(Boolean).length
+}
+```
+
+**Time:** O(n log log n) — effectively linear. **Space:** O(n) for the boolean array.
+
+Two optimizations hiding in plain sight:
+
+- Outer loop stops at `p * p < n`: any composite below n has a prime factor at most √n, so bigger primes have nothing new to cross out.
+- Inner loop starts at `p * p`, not `2p`: smaller multiples like `3p` or `5p` were already crossed out by the smaller primes 3 and 5.
+
+## Dry run
+
+`n = 20`. Start with 2…19 all marked prime.
+
+<Table
+  data={{
+    headers: ['Prime p', 'Crosses out (from p²)', 'Still prime after'],
+    rows: [
+      ['2', '4, 6, 8, 10, 12, 14, 16, 18', '2 3 5 7 9 11 13 15 17 19'],
+      ['3', '9, 12, 15, 18', '2 3 5 7 11 13 17 19'],
+      ['4', 'skipped — already crossed out', '—'],
+      ['5', '5² = 25 ≥ 20 → outer loop ends', '—'],
+    ],
+  }}
+/>
+
+Survivors: 2, 3, 5, 7, 11, 13, 17, 19 → **8 primes**. Notice 12 and 18 get crossed twice (once by 2, once by 3) — harmless, and the log log factor comes from exactly this overlap.
+
+## Edge cases
+
+- `n = 0, 1, 2` → 0 (there are no primes *below* 2 — "strictly less than" is easy to misread).
+- `n = 3` → 1 (just the prime 2).
+- 1 is not prime — forgetting `isPrime[1] = false` inflates the count by one.
+- Memory matters at scale: for huge n, a bit-packed array (or `Uint8Array` in JavaScript) keeps the sieve cache-friendly.

--- a/src/app/dsa/patterns/questions/course-schedule.mdx
+++ b/src/app/dsa/patterns/questions/course-schedule.mdx
@@ -1,0 +1,113 @@
+---
+title: "Course Schedule"
+pattern: "graphs"
+order: 902
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/course-schedule/"
+gfg: "https://www.geeksforgeeks.org/dsa/topological-sorting-indegree-based-solution-kahns-algorithm/"
+summary: "Prerequisites form a directed graph — you can finish all courses exactly when that graph has no cycle. Enter topological sort."
+---
+
+## The problem
+
+There are `numCourses` courses labeled `0` to `numCourses - 1`, and a list of pairs `[a, b]` meaning *you must take course `b` before course `a`*. Return whether it's possible to finish all courses.
+
+**Example 1:** `numCourses = 2`, `prerequisites = [[1, 0]]` → `true` (take 0, then 1).
+
+**Example 2:** `numCourses = 2`, `prerequisites = [[1, 0], [0, 1]]` → `false` — each course requires the other. Deadlock.
+
+Model it as a directed graph: an edge `b → a` for each pair. A valid order exists **iff the graph has no cycle** — and finding such an order is called a topological sort.
+
+## Approach 1 — Kahn's algorithm (BFS by in-degree)
+
+A course with **in-degree 0** (no unmet prerequisites) can be taken right now. Take it, which "removes" its outgoing edges, possibly freeing other courses. If we can take all n courses this way, there's no cycle; if we stall, the leftover courses form a cycle.
+
+```js
+function canFinish(numCourses, prerequisites) {
+  const graph = Array.from({ length: numCourses }, () => [])
+  const inDegree = new Array(numCourses).fill(0)
+
+  for (const [course, prereq] of prerequisites) {
+    graph[prereq].push(course)
+    inDegree[course]++
+  }
+
+  const queue = []
+  for (let i = 0; i < numCourses; i++) {
+    if (inDegree[i] === 0) queue.push(i)
+  }
+
+  let taken = 0
+  while (queue.length > 0) {
+    const course = queue.shift()
+    taken++
+    for (const next of graph[course]) {
+      inDegree[next]--
+      if (inDegree[next] === 0) queue.push(next)
+    }
+  }
+  return taken === numCourses
+}
+```
+
+**Time:** O(V + E) — each course enters the queue once, each edge is relaxed once. **Space:** O(V + E) for the adjacency list.
+
+## Approach 2 — DFS cycle detection (three colors)
+
+DFS from every node, tracking each node's state: **unvisited**, **in the current path** (being explored), or **done**. Meeting an "in the current path" node again means we've looped back — a cycle.
+
+```js
+function canFinish(numCourses, prerequisites) {
+  const graph = Array.from({ length: numCourses }, () => [])
+  for (const [course, prereq] of prerequisites) {
+    graph[prereq].push(course)
+  }
+
+  const state = new Array(numCourses).fill(0) // 0 new, 1 in path, 2 done
+
+  function hasCycle(node) {
+    if (state[node] === 1) return true  // back edge — cycle
+    if (state[node] === 2) return false // already fully explored
+    state[node] = 1
+    for (const next of graph[node]) {
+      if (hasCycle(next)) return true
+    }
+    state[node] = 2
+    return false
+  }
+
+  for (let i = 0; i < numCourses; i++) {
+    if (hasCycle(i)) return false
+  }
+  return true
+}
+```
+
+Same O(V + E). The three-state distinction is essential: a plain `visited` boolean can't tell "ancestor in my current path" (cycle) from "explored earlier via another route" (fine).
+
+## Dry run
+
+Kahn's algorithm with `numCourses = 4`, `prerequisites = [[1, 0], [2, 0], [3, 1], [3, 2]]` (edges 0→1, 0→2, 1→3, 2→3):
+
+In-degrees to start: `[0, 1, 1, 2]`.
+
+<Table
+  data={{
+    headers: ['Step', 'Queue', 'Take', 'Edges relaxed', 'In-degrees after', 'taken'],
+    rows: [
+      ['1', '[0]', '0', '1 and 2 drop to 0', '[-, 0, 0, 2]', '1'],
+      ['2', '[1, 2]', '1', '3 drops to 1', '[-, -, 0, 1]', '2'],
+      ['3', '[2]', '2', '3 drops to 0', '[-, -, -, 0]', '3'],
+      ['4', '[3]', '3', 'none', 'all taken', '4'],
+    ],
+  }}
+/>
+
+`taken === 4 === numCourses` → `true`. Add the edge 3→0 and step 1 would find *no* course with in-degree 0 — the queue starts empty, `taken` stays 0, and the answer is `false`.
+
+## Edge cases
+
+- No prerequisites → every in-degree is 0 → trivially `true`.
+- A self-prerequisite `[a, a]` is a 1-node cycle; both approaches catch it.
+- Disconnected groups of courses are fine — the outer loop (or the initial queue fill) covers every component.
+- The follow-up, Course Schedule II, is the same code returning the order in which courses were taken.

--- a/src/app/dsa/patterns/questions/daily-temperatures.mdx
+++ b/src/app/dsa/patterns/questions/daily-temperatures.mdx
@@ -1,0 +1,97 @@
+---
+title: "Daily Temperatures"
+pattern: "stack"
+order: 602
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/daily-temperatures/"
+gfg: "https://www.geeksforgeeks.org/dsa/next-greater-element/"
+summary: "The monotonic stack in its natural habitat — every 'next greater element' question is this problem wearing a costume."
+---
+
+## The problem
+
+Given daily temperatures, return an array where `answer[i]` is the number of days you must wait after day `i` for a **warmer** temperature. If no warmer day comes, `answer[i] = 0`.
+
+**Example:** `temperatures = [73, 74, 75, 71, 69, 72, 76, 73]`
+
+The answer is `[1, 1, 4, 2, 1, 1, 0, 0]`. Day 2 (75°) waits 4 days because 71, 69, and 72 are all cooler — the next warmer day is day 6 (76°).
+
+This is "next greater element to the right" with distances instead of values.
+
+## Approach 1 — Scan forward for each day
+
+```js
+function dailyTemperatures(temperatures) {
+  const n = temperatures.length
+  const answer = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (temperatures[j] > temperatures[i]) {
+        answer[i] = j - i
+        break
+      }
+    }
+  }
+  return answer
+}
+```
+
+**Time:** O(n²) — a decreasing sequence like `[80, 79, 78, ...]` makes every inner scan run to the end. **Space:** O(1).
+
+## Approach 2 — Monotonic stack
+
+Walk the array once, keeping a stack of indices whose warmer day hasn't been found yet. Invariant: temperatures at stacked indices are **strictly decreasing** from bottom to top.
+
+When a new temperature arrives, it *is* the answer for every stacked index that's cooler — pop them all, record their distances, then push the new index.
+
+```js
+function dailyTemperatures(temperatures) {
+  const answer = new Array(temperatures.length).fill(0)
+  const stack = [] // indices with unresolved answers, temps decreasing
+
+  for (let i = 0; i < temperatures.length; i++) {
+    while (
+      stack.length > 0 &&
+      temperatures[i] > temperatures[stack[stack.length - 1]]
+    ) {
+      const j = stack.pop()
+      answer[j] = i - j
+    }
+    stack.push(i)
+  }
+  return answer
+}
+```
+
+**Time:** O(n) — despite the nested `while`, each index is pushed once and popped at most once, so total work is 2n. **Space:** O(n) for the stack.
+
+## Dry run
+
+`temperatures = [73, 74, 75, 71, 69, 72, 76, 73]`
+
+<Table
+  data={{
+    headers: ['i', 'Temp', 'Pops (index: distance)', 'Stack after (indices)'],
+    rows: [
+      ['0', '73', '—', '0'],
+      ['1', '74', '0: 1', '1'],
+      ['2', '75', '1: 1', '2'],
+      ['3', '71', '—', '2, 3'],
+      ['4', '69', '—', '2, 3, 4'],
+      ['5', '72', '4: 1, then 3: 2', '2, 5'],
+      ['6', '76', '5: 1, then 2: 4', '6'],
+      ['7', '73', '—', '6, 7'],
+    ],
+  }}
+/>
+
+Indices 6 and 7 never get popped — their answers stay `0`, meaning no warmer day exists.
+
+Result: `[1, 1, 4, 2, 1, 1, 0, 0]`.
+
+## Edge cases
+
+- Strictly decreasing input → nothing ever pops; all zeros, and the stack holds every index.
+- Strictly increasing input → every element pops exactly one predecessor; all ones.
+- Equal temperatures don't pop (the comparison is strict `>`), which is correct — "warmer" means strictly greater.
+- Flip the comparison and/or direction of travel, and the same skeleton solves Next Greater Element, Largest Rectangle in Histogram, and stock-span problems.

--- a/src/app/dsa/patterns/questions/factorial-trailing-zeroes.mdx
+++ b/src/app/dsa/patterns/questions/factorial-trailing-zeroes.mdx
@@ -1,0 +1,90 @@
+---
+title: "Factorial Trailing Zeroes"
+pattern: "math"
+order: 1204
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/factorial-trailing-zeroes/"
+gfg: "https://www.geeksforgeeks.org/dsa/count-trailing-zeroes-factorial-number/"
+summary: "You can't compute 100! — but you don't need to. Trailing zeros come from factors of 5, and you can count those directly."
+---
+
+## The problem
+
+Given an integer `n`, return the number of trailing zeroes in `n!` (n factorial).
+
+**Example:** `n = 10` → `10! = 3,628,800` → answer `2`.
+
+## Approach 1 — Compute the factorial (and why you can't)
+
+```js
+// Breaks past n = 18
+function trailingZeroes(n) {
+  let f = 1
+  for (let i = 2; i <= n; i++) f *= i
+  let count = 0
+  while (f % 10 === 0) {
+    count++
+    f /= 10
+  }
+  return count
+}
+```
+
+`21!` already exceeds `Number.MAX_SAFE_INTEGER`; `100!` has 158 digits. `BigInt` technically works but does enormous arithmetic for a question whose answer is a small count. The number itself was never the point.
+
+## Approach 2 — Count factors of 5
+
+A trailing zero is a factor of 10 = 2 × 5. In `n! = 1 × 2 × ... × n`, factors of 2 are everywhere (every second number), factors of 5 are scarce (every fifth) — so **the 5s are the bottleneck**, and the answer is simply how many times 5 divides into n!.
+
+Count them with Legendre's formula: multiples of 5 each give one 5, multiples of 25 give a *second* one, multiples of 125 a third...
+
+`zeroes = floor(n/5) + floor(n/25) + floor(n/125) + ...`
+
+```js
+function trailingZeroes(n) {
+  let count = 0
+  for (let p = 5; p <= n; p *= 5) {
+    count += Math.floor(n / p)
+  }
+  return count
+}
+```
+
+Equivalently, divide n by 5 repeatedly:
+
+```js
+function trailingZeroes(n) {
+  let count = 0
+  while (n > 0) {
+    n = Math.floor(n / 5)
+    count += n
+  }
+  return count
+}
+```
+
+**Time:** O(log₅ n) — a handful of divisions even for n in the billions. **Space:** O(1).
+
+## Dry run
+
+`n = 100`:
+
+<Table
+  data={{
+    headers: ['Power of 5', 'floor(100 / p)', 'What it counts', 'Running total'],
+    rows: [
+      ['5', '20', '5, 10, 15, …, 100 — one 5 each', '20'],
+      ['25', '4', '25, 50, 75, 100 — a second 5 each', '24'],
+      ['125', '0', '125 > 100 — loop ends', '24'],
+    ],
+  }}
+/>
+
+So `100!` ends in **24** zeros — without ever computing its 158 digits. Sanity-check with `n = 10`: `floor(10/5) = 2`, matching the `3,628,800` example.
+
+## Edge cases
+
+- `n = 0` → `0!` = 1 → zero trailing zeroes; the loop never runs.
+- `n < 5` → 0 (no factor of 5 exists yet).
+- The double-counting trap: naively counting only multiples of 5 gives `zeroes(25) = 5`, but 25 contributes **two** fives — the correct answer is 6. The 25/125/625 terms exist precisely for this.
+- Why not count 2s as well? `floor(n/2) + floor(n/4) + ...` is always ≥ the count of 5s, so `min(twos, fives) = fives` — worth stating in an interview.

--- a/src/app/dsa/patterns/questions/gcd-euclidean.mdx
+++ b/src/app/dsa/patterns/questions/gcd-euclidean.mdx
@@ -1,0 +1,91 @@
+---
+title: "GCD of Two Numbers (Euclid's Algorithm)"
+pattern: "math"
+order: 1203
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/find-greatest-common-divisor-of-array/"
+gfg: "https://www.geeksforgeeks.org/dsa/euclidean-algorithms-basic-and-extended/"
+summary: "The oldest algorithm still in daily use — replace the bigger number with a remainder until one hits zero."
+---
+
+## The problem
+
+Compute the **greatest common divisor** of two non-negative integers — the largest number that divides both. It's the building block behind fraction reduction, LCM, GCD-of-array problems (like the linked LeetCode one), and rotation tricks.
+
+**Example:** `gcd(48, 18) = 6`, since 6 divides both and nothing larger does.
+
+## Approach 1 — Try every candidate
+
+```js
+function gcd(a, b) {
+  let best = 1
+  for (let d = 1; d <= Math.min(a, b); d++) {
+    if (a % d === 0 && b % d === 0) best = d
+  }
+  return best
+}
+```
+
+**Time:** O(min(a, b)). Fine for small inputs, useless for 18-digit numbers.
+
+## Approach 2 — Euclid's algorithm
+
+The insight (circa 300 BC): **any common divisor of `a` and `b` also divides `a mod b`** — because `a mod b = a - k·b` for some integer k. So the pair `(a, b)` and the pair `(b, a mod b)` have exactly the same set of common divisors, hence the same GCD. Shrink until one number becomes 0; the other is the answer.
+
+```js
+function gcd(a, b) {
+  while (b !== 0) {
+    ;[a, b] = [b, a % b]
+  }
+  return a
+}
+```
+
+Or recursively, closer to how it's usually stated:
+
+```js
+function gcd(a, b) {
+  return b === 0 ? a : gcd(b, a % b)
+}
+```
+
+**Time:** O(log min(a, b)) — the remainder at least halves every *two* steps (worst case: consecutive Fibonacci numbers). **Space:** O(1) iterative.
+
+## Dry run
+
+`gcd(48, 18)`:
+
+<Table
+  data={{
+    headers: ['Step', 'a', 'b', 'a mod b'],
+    rows: [
+      ['1', '48', '18', '48 mod 18 = 12'],
+      ['2', '18', '12', '18 mod 12 = 6'],
+      ['3', '12', '6', '12 mod 6 = 0'],
+      ['4', '6', '0', 'b = 0 → answer 6'],
+    ],
+  }}
+/>
+
+Three modulo operations. The brute-force loop would have tested 18 candidates — and for 12-digit inputs the gap becomes billions vs. about 50.
+
+## Using it: LCM and GCD of an array
+
+The two classic one-liners built on top:
+
+```js
+// lcm·gcd = a·b — divide FIRST to avoid overflow in fixed-width languages
+const lcm = (a, b) => (a / gcd(a, b)) * b
+
+// GCD is associative — fold it across the array
+const gcdOfArray = (nums) => nums.reduce((acc, x) => gcd(acc, x))
+```
+
+The linked LeetCode problem (GCD of smallest and largest array element) is just `gcd(Math.min(...nums), Math.max(...nums))`.
+
+## Edge cases
+
+- `gcd(a, 0) = a` — the loop's exit condition encodes this convention.
+- `gcd(0, 0)` is conventionally 0; the code returns that naturally.
+- Order doesn't matter: `gcd(18, 48)` spends its first step swapping into `(48 mod 18)` territory anyway.
+- Negative inputs: take absolute values first — a GCD is defined as non-negative.

--- a/src/app/dsa/patterns/questions/happy-number.mdx
+++ b/src/app/dsa/patterns/questions/happy-number.mdx
@@ -1,0 +1,97 @@
+---
+title: "Happy Number"
+pattern: "fast-slow-pointers"
+order: 302
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/happy-number/"
+gfg: "https://www.geeksforgeeks.org/dsa/happy-number/"
+summary: "Fast & slow pointers without a linked list — any process that feeds a value back into itself forms an implicit chain you can cycle-detect."
+---
+
+## The problem
+
+A number is **happy** if repeatedly replacing it with the sum of the squares of its digits eventually reaches `1`. If the process loops forever without hitting `1`, the number is unhappy. Return whether `n` is happy.
+
+**Example:** `n = 19` → `1² + 9² = 82` → `8² + 2² = 68` → `6² + 8² = 100` → `1² + 0² + 0² = 1`. So `19` is happy.
+
+An unhappy number like `2` falls into the famous cycle `4 → 16 → 37 → 58 → 89 → 145 → 42 → 20 → 4 → ...` and never reaches `1`.
+
+The insight: each number has exactly one successor, so the process traces a linked-list-shaped chain — and "never reaches 1" means "the chain has a cycle". That's the same problem as Linked List Cycle.
+
+First, the shared helper:
+
+```js
+function sumOfSquaredDigits(n) {
+  let sum = 0
+  while (n > 0) {
+    const digit = n % 10
+    sum += digit * digit
+    n = Math.floor(n / 10)
+  }
+  return sum
+}
+```
+
+## Approach 1 — Track seen values in a set
+
+Iterate, and stop when we hit `1` (happy) or a repeated value (cycle → unhappy).
+
+```js
+function isHappy(n) {
+  const seen = new Set()
+  while (n !== 1 && !seen.has(n)) {
+    seen.add(n)
+    n = sumOfSquaredDigits(n)
+  }
+  return n === 1
+}
+```
+
+**Time:** effectively O(log n) per step, bounded chain length. **Space:** O(number of values seen) for the set.
+
+## Approach 2 — Floyd's fast & slow pointers
+
+No set needed. Run `slow` one step and `fast` two steps along the implicit chain. If they meet at `1`, happy; if they meet anywhere else, we're inside a cycle.
+
+```js
+function isHappy(n) {
+  let slow = n
+  let fast = sumOfSquaredDigits(n)
+
+  while (fast !== 1 && slow !== fast) {
+    slow = sumOfSquaredDigits(slow)
+    fast = sumOfSquaredDigits(sumOfSquaredDigits(fast))
+  }
+  return fast === 1
+}
+```
+
+**Time:** same order as approach 1. **Space:** O(1) — this is the reason to know the trick.
+
+## Dry run
+
+`n = 2`, whose chain is `2 → 4 → 16 → 37 → 58 → 89 → 145 → 42 → 20 → 4 → ...`
+
+<Table
+  data={{
+    headers: ['Step', 'slow', 'fast', 'Note'],
+    rows: [
+      ['start', '2', '4', 'slow moves 1 link, fast moves 2'],
+      ['1', '4', '37', ''],
+      ['2', '16', '89', ''],
+      ['3', '37', '42', ''],
+      ['4', '58', '4', 'fast has lapped into the cycle'],
+      ['5', '89', '37', ''],
+      ['6', '145', '89', ''],
+      ['7', '42', '42', 'Met at 42 ≠ 1 → unhappy'],
+    ],
+  }}
+/>
+
+For `n = 19`, `fast` reaches `1` after two steps (`19 → 82 → 68 → 100 → 1` chain, fast jumps two at a time) and the loop exits with `fast === 1` → happy.
+
+## Edge cases
+
+- `n = 1` → the loop guard `fast !== 1` fails immediately → `true`.
+- Why can't the chain grow forever instead of cycling? A 3-digit number maps to at most `3 × 81 = 243`, so every chain is eventually trapped below 244 — with finitely many values, it must repeat.
+- The same two-pointer idea works for any "apply f repeatedly, detect a loop" problem — see also Find the Duplicate Number (LeetCode 287).

--- a/src/app/dsa/patterns/questions/koko-eating-bananas.mdx
+++ b/src/app/dsa/patterns/questions/koko-eating-bananas.mdx
@@ -1,0 +1,88 @@
+---
+title: "Koko Eating Bananas"
+pattern: "binary-search"
+order: 502
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/koko-eating-bananas/"
+gfg: "https://www.geeksforgeeks.org/dsa/koko-eating-bananas/"
+summary: "Binary search on the answer, not the array — when a yes/no condition flips from false to true exactly once, you can search the answer space."
+---
+
+## The problem
+
+Koko has `piles` of bananas and `h` hours. Each hour she picks one pile and eats up to `k` bananas from it (a pile smaller than `k` still consumes the whole hour). Find the **minimum eating speed `k`** that finishes all piles within `h` hours.
+
+**Example:** `piles = [3, 6, 7, 11]`, `h = 8` → answer `4`.
+
+At speed 4, the piles take `ceil(3/4) + ceil(6/4) + ceil(7/4) + ceil(11/4) = 1 + 2 + 2 + 3 = 8` hours — exactly in budget. At speed 3 it would take `1 + 2 + 3 + 4 = 10` hours — too slow.
+
+There's no array to search here. The trick is to notice **monotonicity**: if speed `k` finishes in time, every faster speed does too. So the predicate "can finish at speed k" looks like `false, false, ..., false, true, true, ..., true` — and binary search can find the first `true`.
+
+## Approach 1 — Try every speed
+
+Check `k = 1, 2, 3, ...` until one works.
+
+```js
+function minEatingSpeed(piles, h) {
+  const hoursAt = (k) =>
+    piles.reduce((sum, pile) => sum + Math.ceil(pile / k), 0)
+
+  let k = 1
+  while (hoursAt(k) > h) k++
+  return k
+}
+```
+
+**Time:** O(max(piles) · n) — with piles up to 10⁹ bananas, this is billions of checks. Correct but far too slow.
+
+## Approach 2 — Binary search on the answer
+
+The answer lies between `1` and `max(piles)` (eating faster than the biggest pile changes nothing). Binary search that range for the first speed that finishes in time.
+
+```js
+function minEatingSpeed(piles, h) {
+  const hoursAt = (k) =>
+    piles.reduce((sum, pile) => sum + Math.ceil(pile / k), 0)
+
+  let lo = 1
+  let hi = Math.max(...piles)
+
+  while (lo < hi) {
+    const mid = lo + Math.floor((hi - lo) / 2)
+    if (hoursAt(mid) <= h) {
+      hi = mid        // mid works — the answer is mid or something smaller
+    } else {
+      lo = mid + 1    // mid too slow — answer must be bigger
+    }
+  }
+  return lo
+}
+```
+
+**Time:** O(n · log(max pile)). **Space:** O(1).
+
+Note the template difference from plain binary search: we never return early. When `mid` *works* we keep it in the window (`hi = mid`) because it might be the minimum; the loop runs until the window collapses to a single value.
+
+## Dry run
+
+`piles = [3, 6, 7, 11]`, `h = 8`. Search space `[1, 11]`.
+
+<Table
+  data={{
+    headers: ['Step', 'lo', 'hi', 'mid', 'Hours at mid', 'Fits in 8?', 'Move'],
+    rows: [
+      ['1', '1', '11', '6', '1+1+2+2 = 6', 'yes', 'hi = 6'],
+      ['2', '1', '6', '3', '1+2+3+4 = 10', 'no', 'lo = 4'],
+      ['3', '4', '6', '5', '1+2+2+3 = 8', 'yes', 'hi = 5'],
+      ['4', '4', '5', '4', '1+2+2+3 = 8', 'yes', 'hi = 4'],
+      ['5', 'lo = hi = 4', '—', '—', '—', '—', 'Answer: 4'],
+    ],
+  }}
+/>
+
+## Edge cases
+
+- `h === piles.length` → she has exactly one hour per pile → answer is `max(piles)`.
+- One pile, many hours: `piles = [1000000]`, `h = 1000000` → answer 1; the log factor keeps this instant.
+- Use `Math.ceil(pile / k)` — integer-dividing and adding one "when there's a remainder" is where off-by-one bugs creep in.
+- Same skeleton solves Capacity to Ship Packages (LC 1011) and Split Array Largest Sum (LC 410): define `feasible(x)`, confirm it's monotonic, binary search the answer space.

--- a/src/app/dsa/patterns/questions/kth-largest-element.mdx
+++ b/src/app/dsa/patterns/questions/kth-largest-element.mdx
@@ -1,0 +1,108 @@
+---
+title: "Kth Largest Element in an Array"
+pattern: "heap-top-k"
+order: 701
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/kth-largest-element-in-an-array/"
+gfg: "https://www.geeksforgeeks.org/dsa/kth-smallest-largest-element-in-unsorted-array/"
+summary: "Keep a min-heap of the k largest seen so far — the heap's smallest element is always your current answer."
+---
+
+## The problem
+
+Find the k-th largest element in an unsorted array (k-th in **sorted order**, not k-th distinct value).
+
+**Example:** `nums = [3, 2, 1, 5, 6, 4]`, `k = 2` → answer `5` (sorted descending: 6, **5**, 4, 3, 2, 1).
+
+## Approach 1 — Sort
+
+```js
+function findKthLargest(nums, k) {
+  return [...nums].sort((a, b) => b - a)[k - 1]
+}
+```
+
+**Time:** O(n log n). **Space:** O(n) for the copy. Perfectly fine in practice — but it sorts all n elements when we only care about the top k.
+
+## Approach 2 — Min-heap of size k
+
+Stream through the array keeping a **min-heap** with at most k elements — the k largest seen so far. Counterintuitively, a *min*-heap: its root is the smallest of the current top-k, i.e. the current k-th largest, and it's the element to evict when something bigger arrives.
+
+JavaScript has no built-in heap, so here's a minimal one (in an interview, say so and ask if you can assume one):
+
+```js
+class MinHeap {
+  constructor() { this.a = [] }
+  size() { return this.a.length }
+  peek() { return this.a[0] }
+  push(v) {
+    this.a.push(v)
+    let i = this.a.length - 1
+    while (i > 0) {
+      const p = (i - 1) >> 1
+      if (this.a[p] <= this.a[i]) break
+      ;[this.a[p], this.a[i]] = [this.a[i], this.a[p]]
+      i = p
+    }
+  }
+  pop() {
+    const top = this.a[0]
+    const last = this.a.pop()
+    if (this.a.length > 0) {
+      this.a[0] = last
+      let i = 0
+      while (true) {
+        const l = 2 * i + 1, r = 2 * i + 2
+        let smallest = i
+        if (l < this.a.length && this.a[l] < this.a[smallest]) smallest = l
+        if (r < this.a.length && this.a[r] < this.a[smallest]) smallest = r
+        if (smallest === i) break
+        ;[this.a[smallest], this.a[i]] = [this.a[i], this.a[smallest]]
+        i = smallest
+      }
+    }
+    return top
+  }
+}
+
+function findKthLargest(nums, k) {
+  const heap = new MinHeap()
+  for (const num of nums) {
+    heap.push(num)
+    if (heap.size() > k) heap.pop() // evict the smallest — it can't be top-k
+  }
+  return heap.peek()
+}
+```
+
+**Time:** O(n log k) — n pushes/pops on a heap that never exceeds k+1 elements. **Space:** O(k). This beats sorting when k is small, and it works on **streams** where you can't hold all of n in memory.
+
+## Approach 3 — Quickselect (average O(n))
+
+Partition around a pivot as in quicksort, but recurse into only the side containing the k-th position. Average O(n), worst case O(n²) with bad pivots; great to mention, and worth coding if the interviewer pushes for linear time.
+
+## Dry run
+
+Approach 2 on `nums = [3, 2, 1, 5, 6, 4]`, `k = 2`:
+
+<Table
+  data={{
+    headers: ['Element', 'Heap after push', 'Size > 2?', 'Evict', 'Heap (k largest so far)'],
+    rows: [
+      ['3', '[3]', 'no', '—', '[3]'],
+      ['2', '[2, 3]', 'no', '—', '[2, 3]'],
+      ['1', '[1, 3, 2]', 'yes', '1', '[2, 3]'],
+      ['5', '[2, 3, 5]', 'yes', '2', '[3, 5]'],
+      ['6', '[3, 5, 6]', 'yes', '3', '[5, 6]'],
+      ['4', '[4, 6, 5]', 'yes', '4', '[5, 6]'],
+    ],
+  }}
+/>
+
+Heap root at the end: `5` — the 2nd largest. Notice how `[5, 6]` are exactly the top-2, and the *min* of them is the answer.
+
+## Edge cases
+
+- `k = 1` → heap of size 1 tracking the max; `k = n` → tracking the min.
+- Duplicates count separately: in `[3, 3, 3]` the 2nd largest is `3`.
+- Negative numbers need no special handling — comparisons do all the work.

--- a/src/app/dsa/patterns/questions/level-order-traversal.mdx
+++ b/src/app/dsa/patterns/questions/level-order-traversal.mdx
@@ -1,0 +1,99 @@
+---
+title: "Binary Tree Level Order Traversal"
+pattern: "tree-bfs-dfs"
+order: 801
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/binary-tree-level-order-traversal/"
+gfg: "https://www.geeksforgeeks.org/dsa/level-order-tree-traversal/"
+summary: "The template for every level-by-level tree question: a queue, plus the level-size snapshot trick."
+---
+
+## The problem
+
+Given the root of a binary tree, return its node values **level by level**, as a list of lists.
+
+**Example:** for the tree below, the answer is `[[3], [9, 20], [15, 7]]`.
+
+```
+      3
+     / \
+    9  20
+       / \
+      15  7
+```
+
+Depth-first traversals (pre/in/post-order) dive down a branch before visiting siblings — the wrong shape here. "Level by level" calls for **breadth-first search**: visit all nodes at distance d before any node at distance d+1. A queue does exactly that.
+
+## Approach 1 — DFS with a depth parameter
+
+BFS is the natural fit, but DFS can also produce level groupings: pass the depth down the recursion and append each node to `result[depth]`.
+
+```js
+function levelOrder(root) {
+  const result = []
+  function dfs(node, depth) {
+    if (!node) return
+    if (result.length === depth) result.push([])
+    result[depth].push(node.val)
+    dfs(node.left, depth + 1)
+    dfs(node.right, depth + 1)
+  }
+  dfs(root, 0)
+  return result
+}
+```
+
+**Time:** O(n). **Space:** O(h) recursion stack. Works because visiting left before right keeps each level list in left-to-right order. Good to know — but the queue version below is the one that generalizes to "zigzag", "right side view", and "rotting oranges"-style problems.
+
+## Approach 2 — BFS with a queue (the standard)
+
+Push the root. Each loop iteration processes **one full level**: snapshot the current queue length, pop exactly that many nodes, and push their children (which form the next level).
+
+```js
+function levelOrder(root) {
+  if (!root) return []
+
+  const result = []
+  const queue = [root]
+
+  while (queue.length > 0) {
+    const levelSize = queue.length // snapshot BEFORE pushing children
+    const level = []
+    for (let i = 0; i < levelSize; i++) {
+      const node = queue.shift()
+      level.push(node.val)
+      if (node.left) queue.push(node.left)
+      if (node.right) queue.push(node.right)
+    }
+    result.push(level)
+  }
+  return result
+}
+```
+
+**Time:** O(n) — each node enters and leaves the queue once. **Space:** O(w), the tree's maximum width (up to n/2 for a bushy tree).
+
+The `levelSize` snapshot is the entire trick: without it, children pushed mid-level would bleed into the current level's loop.
+
+## Dry run
+
+Tree: `3` with children `9`, `20`; `20` with children `15`, `7`.
+
+<Table
+  data={{
+    headers: ['Iteration', 'Queue at start', 'levelSize', 'Popped', 'Pushed', 'result'],
+    rows: [
+      ['1', '[3]', '1', '3', '9, 20', '[[3]]'],
+      ['2', '[9, 20]', '2', '9, then 20', '15, 7 (from 20)', '[[3], [9, 20]]'],
+      ['3', '[15, 7]', '2', '15, then 7', 'nothing', '[[3], [9, 20], [15, 7]]'],
+      ['4', '[]', '—', '—', '—', 'queue empty — done'],
+    ],
+  }}
+/>
+
+## Edge cases
+
+- Empty tree → `[]` (the early return).
+- Skewed tree (every node has one child) → each level is a single-element list; the queue never holds more than one node.
+- `Array.prototype.shift()` is O(n) in the worst case; for very large trees use an index pointer into the array instead of shifting. Interviewers rarely mind, but knowing it is a plus.
+- Variants that reuse this exact skeleton: Zigzag Level Order (alternate reversing `level`), Right Side View (keep the last node per level), Average of Levels.

--- a/src/app/dsa/patterns/questions/linked-list-cycle.mdx
+++ b/src/app/dsa/patterns/questions/linked-list-cycle.mdx
@@ -1,0 +1,85 @@
+---
+title: "Linked List Cycle"
+pattern: "fast-slow-pointers"
+order: 301
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/linked-list-cycle/"
+gfg: "https://www.geeksforgeeks.org/dsa/detect-loop-in-a-linked-list/"
+summary: "Floyd's tortoise and hare — detect a cycle with two pointers and zero extra memory, instead of remembering every node you've seen."
+---
+
+## The problem
+
+Given the head of a linked list, return `true` if the list contains a cycle — that is, if following `next` pointers ever revisits a node — and `false` if the list terminates in `null`.
+
+**Example:** `3 → 2 → 0 → -4`, where the `-4` node's `next` points back to the `2` node. This list has a cycle, so the answer is `true`.
+
+The catch: you can't just walk the list and wait for `null`, because in a cyclic list you'll loop forever.
+
+## Approach 1 — Remember visited nodes
+
+Walk the list and store each **node reference** (not value — values can repeat) in a set. Seeing a node twice means a cycle.
+
+```js
+function hasCycle(head) {
+  const visited = new Set()
+  let node = head
+  while (node !== null) {
+    if (visited.has(node)) return true
+    visited.add(node)
+    node = node.next
+  }
+  return false
+}
+```
+
+**Time:** O(n). **Space:** O(n) — the set can grow to hold every node. Correct, but the follow-up asks for constant memory.
+
+## Approach 2 — Floyd's fast & slow pointers
+
+Move `slow` one step and `fast` two steps at a time.
+
+- If the list ends, `fast` hits `null` → no cycle.
+- If there's a cycle, both pointers eventually enter it, and inside the cycle `fast` gains on `slow` by exactly one node per step — so it must land on `slow` rather than skip over it.
+
+```js
+function hasCycle(head) {
+  let slow = head
+  let fast = head
+
+  while (fast !== null && fast.next !== null) {
+    slow = slow.next
+    fast = fast.next.next
+    if (slow === fast) return true
+  }
+  return false
+}
+```
+
+**Time:** O(n) — slow never completes two laps before being caught. **Space:** O(1). Two pointers, nothing else.
+
+## Dry run
+
+List: `3 → 2 → 0 → -4`, with `-4 → 2` closing the cycle.
+
+<Table
+  data={{
+    headers: ['Step', 'slow at', 'fast at', 'Met?'],
+    rows: [
+      ['start', '3', '3', '—'],
+      ['1', '2', '0', 'no'],
+      ['2', '0', '2', 'no'],
+      ['3', '-4', '-4', 'yes — cycle detected'],
+    ],
+  }}
+/>
+
+For a cycle-free list like `1 → 2 → 3 → null`, `fast` would reach `null` on step 2 and the function returns `false`.
+
+## Edge cases
+
+- Empty list or single node with `next = null` → the loop guard fails immediately → `false`.
+- Single node pointing to itself → step 1 puts both pointers on that node → `true`.
+- The loop condition checks `fast` **and** `fast.next` — dropping either causes a null-pointer error on odd-length lists.
+
+**Bonus:** to find *where* the cycle starts (Linked List Cycle II), reset one pointer to `head` after the meeting and advance both one step at a time; they meet at the cycle's entry node.

--- a/src/app/dsa/patterns/questions/longest-substring-without-repeating.mdx
+++ b/src/app/dsa/patterns/questions/longest-substring-without-repeating.mdx
@@ -1,0 +1,116 @@
+---
+title: "Longest Substring Without Repeating Characters"
+pattern: "sliding-window"
+order: 202
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/longest-substring-without-repeating-characters/"
+gfg: "https://www.geeksforgeeks.org/dsa/length-of-the-longest-substring-without-repeating-characters/"
+summary: "The classic variable-size window: grow the right edge greedily, shrink the left edge only when a character repeats."
+---
+
+## The problem
+
+Given a string, find the length of the **longest substring** (contiguous!) that has no repeating characters.
+
+**Example:** `s = "abcabcbb"`
+
+The answer is `3` — the substring `"abc"`. Note that `"abca"` breaks the rule because `a` repeats, and something like `"abcb..."` can never recover once `b` repeats until we drop the earlier `b`.
+
+Unlike the fixed-window problem, the window size here changes: we want the *largest* window that stays valid (all characters unique).
+
+## Approach 1 — Check every substring
+
+For each pair of start/end positions, check uniqueness with a set.
+
+```js
+function lengthOfLongestSubstring(s) {
+  let best = 0
+  for (let i = 0; i < s.length; i++) {
+    const seen = new Set()
+    for (let j = i; j < s.length; j++) {
+      if (seen.has(s[j])) break
+      seen.add(s[j])
+      best = Math.max(best, j - i + 1)
+    }
+  }
+  return best
+}
+```
+
+**Time:** O(n²). **Space:** O(min(n, alphabet)). The inner loop restarts from scratch for every `i`, re-scanning characters we've already looked at.
+
+## Approach 2 — Sliding window with a Set
+
+Keep a window `[left, right]` containing no duplicates. Move `right` forward one character at a time; if the new character already exists in the window, shrink from the left until it doesn't.
+
+```js
+function lengthOfLongestSubstring(s) {
+  const window = new Set()
+  let left = 0
+  let best = 0
+
+  for (let right = 0; right < s.length; right++) {
+    while (window.has(s[right])) {
+      window.delete(s[left])
+      left++
+    }
+    window.add(s[right])
+    best = Math.max(best, right - left + 1)
+  }
+  return best
+}
+```
+
+**Time:** O(n) — `left` and `right` each move forward at most n times total. **Space:** O(min(n, alphabet)).
+
+## Approach 3 — Jump the left pointer with a map
+
+Instead of shrinking one step at a time, remember each character's last index and jump `left` directly past the previous occurrence.
+
+```js
+function lengthOfLongestSubstring(s) {
+  const lastIndex = new Map()
+  let left = 0
+  let best = 0
+
+  for (let right = 0; right < s.length; right++) {
+    const ch = s[right]
+    if (lastIndex.has(ch) && lastIndex.get(ch) >= left) {
+      left = lastIndex.get(ch) + 1
+    }
+    lastIndex.set(ch, right)
+    best = Math.max(best, right - left + 1)
+  }
+  return best
+}
+```
+
+Same O(n) time, but each character is now processed exactly once with no inner loop. The `>= left` check matters: an old occurrence *behind* the window must not drag `left` backward.
+
+## Dry run
+
+Approach 3 on `s = "abcabcbb"`:
+
+<Table
+  data={{
+    headers: ['right', 'Char', 'Seen before in window?', 'left', 'Window', 'Best'],
+    rows: [
+      ['0', 'a', 'no', '0', 'a', '1'],
+      ['1', 'b', 'no', '0', 'ab', '2'],
+      ['2', 'c', 'no', '0', 'abc', '3'],
+      ['3', 'a', 'yes (index 0)', '1', 'bca', '3'],
+      ['4', 'b', 'yes (index 1)', '2', 'cab', '3'],
+      ['5', 'c', 'yes (index 2)', '3', 'abc', '3'],
+      ['6', 'b', 'yes (index 4)', '5', 'cb', '3'],
+      ['7', 'b', 'yes (index 6)', '7', 'b', '3'],
+    ],
+  }}
+/>
+
+The window slides across the string once, and the best length it ever reaches is `3`.
+
+## Edge cases
+
+- Empty string → `0` (the loop never runs).
+- All identical characters `"bbbb"` → `1`; the window never grows past one character.
+- A string of all-unique characters → the answer is the whole length; the `while`/jump never fires.

--- a/src/app/dsa/patterns/questions/max-average-subarray.mdx
+++ b/src/app/dsa/patterns/questions/max-average-subarray.mdx
@@ -1,0 +1,80 @@
+---
+title: "Maximum Average Subarray I"
+pattern: "sliding-window"
+order: 201
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/maximum-average-subarray-i/"
+gfg: "https://www.geeksforgeeks.org/dsa/window-sliding-technique/"
+summary: "The canonical fixed-size window: slide by adding one element and removing another, instead of re-summing k elements every time."
+---
+
+## The problem
+
+Given an array `nums` and an integer `k`, find the contiguous subarray of length **exactly k** with the maximum average, and return that average.
+
+**Example:** `nums = [1, 12, -5, -6, 50, 3]`, `k = 4`
+
+The answer is `12.75`, from the window `[12, -5, -6, 50]` whose sum is `51` and average `51 / 4 = 12.75`.
+
+Since `k` is fixed, maximizing the average is the same as maximizing the window **sum** — divide once at the end.
+
+## Approach 1 — Recompute every window
+
+For each starting index, sum the next `k` elements.
+
+```js
+function findMaxAverage(nums, k) {
+  let best = -Infinity
+  for (let i = 0; i + k <= nums.length; i++) {
+    let sum = 0
+    for (let j = i; j < i + k; j++) sum += nums[j]
+    best = Math.max(best, sum)
+  }
+  return best / k
+}
+```
+
+**Time:** O(n · k) — adjacent windows share `k - 1` elements, and we re-add all of them every time. **Space:** O(1).
+
+## Approach 2 — Sliding window
+
+Adjacent windows differ by exactly two elements: the one entering on the right and the one leaving on the left. So keep a running sum and update it in O(1) per slide:
+
+```js
+function findMaxAverage(nums, k) {
+  let windowSum = 0
+  for (let i = 0; i < k; i++) windowSum += nums[i]
+
+  let best = windowSum
+  for (let i = k; i < nums.length; i++) {
+    windowSum += nums[i] - nums[i - k] // add entering, drop leaving
+    best = Math.max(best, windowSum)
+  }
+  return best / k
+}
+```
+
+**Time:** O(n) — each element enters the window once and leaves once. **Space:** O(1).
+
+## Dry run
+
+`nums = [1, 12, -5, -6, 50, 3]`, `k = 4`. First window `[1, 12, -5, -6]` sums to `2`.
+
+<Table
+  data={{
+    headers: ['Window', 'Enters', 'Leaves', 'Window sum', 'Best so far'],
+    rows: [
+      ['[1, 12, -5, -6]', '—', '—', '2', '2'],
+      ['[12, -5, -6, 50]', '50', '1', '2 + 50 - 1 = 51', '51'],
+      ['[-5, -6, 50, 3]', '3', '12', '51 + 3 - 12 = 42', '51'],
+    ],
+  }}
+/>
+
+Final answer: `51 / 4 = 12.75`. Two additions per slide, no matter how large `k` is.
+
+## Edge cases
+
+- `k === nums.length` → one window, the loop body never runs, and the initial sum is the answer.
+- Negative numbers are why `best` starts at the first window's sum (or `-Infinity`), never at `0`.
+- Overflow isn't a concern in JavaScript here, but in other languages the running sum should be a 64-bit type.

--- a/src/app/dsa/patterns/questions/merge-intervals.mdx
+++ b/src/app/dsa/patterns/questions/merge-intervals.mdx
@@ -1,0 +1,99 @@
+---
+title: "Merge Intervals"
+pattern: "merge-intervals"
+order: 401
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/merge-intervals/"
+gfg: "https://www.geeksforgeeks.org/dsa/merging-intervals/"
+summary: "Sort by start, then one linear sweep: each interval either extends the last merged one or starts a new group."
+---
+
+## The problem
+
+Given a list of intervals `[start, end]`, merge all overlapping intervals and return the non-overlapping result.
+
+**Example:** `intervals = [[1, 3], [2, 6], [8, 10], [15, 18]]`
+
+The answer is `[[1, 6], [8, 10], [15, 18]]` — `[1, 3]` and `[2, 6]` overlap (2 ≤ 3), so they fuse into `[1, 6]`. The others don't touch anything.
+
+Two intervals `a` and `b` (with `a` starting first) overlap exactly when `b.start <= a.end`. Intervals that merely touch, like `[1, 4]` and `[4, 5]`, count as overlapping here.
+
+## Approach 1 — Repeated pairwise merging
+
+Compare every pair; merge any overlapping pair and restart until nothing changes.
+
+```js
+function merge(intervals) {
+  let list = intervals.map((x) => [...x])
+  let changed = true
+  while (changed) {
+    changed = false
+    outer: for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) {
+        if (list[j][0] <= list[i][1] && list[i][0] <= list[j][1]) {
+          list[i] = [
+            Math.min(list[i][0], list[j][0]),
+            Math.max(list[i][1], list[j][1]),
+          ]
+          list.splice(j, 1)
+          changed = true
+          break outer
+        }
+      }
+    }
+  }
+  return list
+}
+```
+
+**Time:** up to O(n³) in bad cases. It works, but the restarts exist only because the intervals are in arbitrary order.
+
+## Approach 2 — Sort, then sweep
+
+Sort by start. Now every interval that could merge with the current group arrives *immediately after it* — so one pass suffices. Keep the last merged interval; for each new one, either extend it or start fresh.
+
+```js
+function merge(intervals) {
+  intervals.sort((a, b) => a[0] - b[0])
+  const merged = [intervals[0].slice()]
+
+  for (let i = 1; i < intervals.length; i++) {
+    const [start, end] = intervals[i]
+    const last = merged[merged.length - 1]
+
+    if (start <= last[1]) {
+      last[1] = Math.max(last[1], end) // overlap — extend the group
+    } else {
+      merged.push([start, end])        // gap — start a new group
+    }
+  }
+  return merged
+}
+```
+
+**Time:** O(n log n) for the sort, O(n) for the sweep. **Space:** O(n) for the output.
+
+## Dry run
+
+`intervals = [[8, 10], [1, 3], [15, 18], [2, 6]]` — note it starts unsorted.
+
+After sorting: `[[1, 3], [2, 6], [8, 10], [15, 18]]`.
+
+<Table
+  data={{
+    headers: ['Current', 'Last merged', 'start <= last.end?', 'Action', 'Result so far'],
+    rows: [
+      ['[1, 3]', '—', '—', 'seed', '[[1, 3]]'],
+      ['[2, 6]', '[1, 3]', '2 <= 3 yes', 'extend end to max(3, 6) = 6', '[[1, 6]]'],
+      ['[8, 10]', '[1, 6]', '8 <= 6 no', 'new group', '[[1, 6], [8, 10]]'],
+      ['[15, 18]', '[8, 10]', '15 <= 10 no', 'new group', '[[1, 6], [8, 10], [15, 18]]'],
+    ],
+  }}
+/>
+
+## Edge cases
+
+- One interval fully inside another: `[1, 10], [2, 3]` — the `Math.max` on the end is what keeps the result `[1, 10]` instead of wrongly shrinking to `[1, 3]`.
+- Touching intervals `[1, 4], [4, 5]` merge because the check is `<=`, not `<`.
+- Single interval → returned as-is.
+- This sort-then-sweep skeleton also solves Insert Interval, Meeting Rooms, and Non-overlapping Intervals — same idea, different bookkeeping.

--- a/src/app/dsa/patterns/questions/non-overlapping-intervals.mdx
+++ b/src/app/dsa/patterns/questions/non-overlapping-intervals.mdx
@@ -1,0 +1,75 @@
+---
+title: "Non-overlapping Intervals"
+pattern: "merge-intervals"
+order: 402
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/non-overlapping-intervals/"
+gfg: "https://www.geeksforgeeks.org/dsa/activity-selection-problem-greedy-algo-1/"
+summary: "Interval scheduling in disguise — sort by end time and greedily keep the interval that frees up the timeline soonest."
+---
+
+## The problem
+
+Given intervals `[start, end]`, return the **minimum number of intervals to remove** so that the rest don't overlap. Intervals that only touch (like `[1, 2]` and `[2, 3]`) do *not* count as overlapping.
+
+**Example:** `intervals = [[1, 2], [2, 3], [3, 4], [1, 3]]`
+
+The answer is `1`: remove `[1, 3]` and the remaining `[1, 2], [2, 3], [3, 4]` are pairwise non-overlapping.
+
+Flip the question: removing the minimum is the same as **keeping the maximum** number of non-overlapping intervals — which is the classic activity-selection problem.
+
+## Approach 1 — Try every subset (why it's hopeless)
+
+Conceptually you could test every subset of intervals for validity and keep the largest — that's O(2ⁿ) subsets. Even smarter DP over sorted intervals (longest chain) costs O(n²). Both are far more work than needed, because a greedy choice is provably safe here.
+
+## Approach 2 — Greedy by earliest end time
+
+Sort by **end** time. Sweep left to right, always keeping the first interval that starts at or after the end of the last kept one.
+
+Why end time? Among all intervals we could keep next, the one that *ends earliest* leaves the most room for future intervals — choosing it can never make the solution worse.
+
+```js
+function eraseOverlapIntervals(intervals) {
+  intervals.sort((a, b) => a[1] - b[1])
+
+  let removed = 0
+  let lastEnd = -Infinity
+
+  for (const [start, end] of intervals) {
+    if (start >= lastEnd) {
+      lastEnd = end     // keep it — no overlap with what we kept
+    } else {
+      removed++         // overlaps the kept set — remove it
+    }
+  }
+  return removed
+}
+```
+
+**Time:** O(n log n) for the sort. **Space:** O(1).
+
+## Dry run
+
+`intervals = [[1, 2], [2, 3], [3, 4], [1, 3]]`
+
+After sorting by end: `[[1, 2], [2, 3], [1, 3], [3, 4]]`.
+
+<Table
+  data={{
+    headers: ['Interval', 'lastEnd', 'start >= lastEnd?', 'Decision', 'removed'],
+    rows: [
+      ['[1, 2]', '-∞', 'yes', 'keep, lastEnd = 2', '0'],
+      ['[2, 3]', '2', '2 >= 2 yes', 'keep, lastEnd = 3', '0'],
+      ['[1, 3]', '3', '1 >= 3 no', 'remove', '1'],
+      ['[3, 4]', '3', '3 >= 3 yes', 'keep, lastEnd = 4', '1'],
+    ],
+  }}
+/>
+
+One removal — matching the expected answer.
+
+## Edge cases
+
+- Touching intervals: the comparison is `start >= lastEnd`, so `[1, 2]` then `[2, 3]` are both kept. If the problem counted touching as overlap, this would become `>`.
+- Sorting by **start** instead of end breaks the greedy: with `[[1, 100], [2, 3], [4, 5]]`, start-order keeps `[1, 100]` first and removes two, while end-order keeps `[2, 3], [4, 5]` and removes one.
+- All identical intervals `[[1, 2], [1, 2], [1, 2]]` → keep one, remove two.

--- a/src/app/dsa/patterns/questions/number-of-islands.mdx
+++ b/src/app/dsa/patterns/questions/number-of-islands.mdx
@@ -1,0 +1,128 @@
+---
+title: "Number of Islands"
+pattern: "graphs"
+order: 901
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/number-of-islands/"
+gfg: "https://www.geeksforgeeks.org/dsa/find-number-of-islands/"
+summary: "The grid is a graph in disguise — flood-fill each unvisited land cell and count how many times you had to start."
+---
+
+## The problem
+
+Given a grid of `'1'` (land) and `'0'` (water), count the islands. An island is a group of land cells connected **horizontally or vertically** (not diagonally).
+
+**Example:**
+
+```
+1 1 0 0 0
+1 1 0 0 0
+0 0 1 0 0
+0 0 0 1 1
+```
+
+The answer is `3`: the 2×2 block top-left, the lone `1` in the middle, and the pair bottom-right.
+
+Reframe it as a graph problem: cells are nodes, adjacent land cells share an edge, and islands are **connected components**. Counting components = starting a traversal from every not-yet-visited node and counting the starts.
+
+## Approach — DFS flood fill
+
+Scan every cell. On finding land, increment the count and "sink" the whole island with DFS (mark every reachable land cell as water) so it's never counted again.
+
+```js
+function numIslands(grid) {
+  const rows = grid.length
+  const cols = grid[0].length
+  let count = 0
+
+  function sink(r, c) {
+    if (r < 0 || r >= rows || c < 0 || c >= cols) return
+    if (grid[r][c] !== '1') return
+    grid[r][c] = '0' // mark visited by sinking
+    sink(r + 1, c)
+    sink(r - 1, c)
+    sink(r, c + 1)
+    sink(r, c - 1)
+  }
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (grid[r][c] === '1') {
+        count++
+        sink(r, c)
+      }
+    }
+  }
+  return count
+}
+```
+
+**Time:** O(rows × cols) — each cell is visited a constant number of times. **Space:** O(rows × cols) worst-case recursion depth (one giant snake-shaped island).
+
+## Approach 2 — BFS with a queue
+
+Same idea, but sink iteratively — useful when recursion depth is a concern.
+
+```js
+function numIslands(grid) {
+  const rows = grid.length
+  const cols = grid[0].length
+  const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]]
+  let count = 0
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (grid[r][c] !== '1') continue
+      count++
+      grid[r][c] = '0'
+      const queue = [[r, c]]
+      while (queue.length > 0) {
+        const [cr, cc] = queue.shift()
+        for (const [dr, dc] of dirs) {
+          const nr = cr + dr
+          const nc = cc + dc
+          if (
+            nr >= 0 && nr < rows &&
+            nc >= 0 && nc < cols &&
+            grid[nr][nc] === '1'
+          ) {
+            grid[nr][nc] = '0' // mark when ENQUEUING, not when popping
+            queue.push([nr, nc])
+          }
+        }
+      }
+    }
+  }
+  return count
+}
+```
+
+Same complexity. Marking cells when they're *enqueued* (not when popped) prevents the same cell from entering the queue twice.
+
+(A third route worth naming: **Union-Find** — union every adjacent land pair, then count roots. Overkill here, but it's the tool when islands must merge dynamically, as in Number of Islands II.)
+
+## Dry run
+
+DFS on the example grid. The outer scan walks row by row:
+
+<Table
+  data={{
+    headers: ['Scan hits', 'Cell state', 'Action', 'count'],
+    rows: [
+      ['(0,0)', 'land', 'count it, DFS sinks (0,0),(0,1),(1,0),(1,1)', '1'],
+      ['(0,1)…(1,1)', 'already sunk', 'skip', '1'],
+      ['(2,2)', 'land', 'count it, DFS sinks just (2,2)', '2'],
+      ['(3,3)', 'land', 'count it, DFS sinks (3,3),(3,4)', '3'],
+      ['(3,4)', 'already sunk', 'skip', '3'],
+    ],
+  }}
+/>
+
+Every land cell is touched exactly once by a sink, so no island is double-counted.
+
+## Edge cases
+
+- All water → 0; all land → 1 (one big flood fill).
+- The grid holds **strings** `'1'`/`'0'` on LeetCode — comparing against the number `1` silently fails.
+- Mutating the input grid is the O(1)-extra-space visited marker; if mutation isn't allowed, carry a separate `visited` set.
+- Diagonals don't connect — only 4 directions in `dirs`.

--- a/src/app/dsa/patterns/questions/pow-x-n.mdx
+++ b/src/app/dsa/patterns/questions/pow-x-n.mdx
@@ -1,0 +1,99 @@
+---
+title: "Pow(x, n) — Fast Exponentiation"
+pattern: "math"
+order: 1202
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/powx-n/"
+gfg: "https://www.geeksforgeeks.org/dsa/write-a-c-program-to-calculate-powxn/"
+summary: "Multiplying x by itself n times is O(n) — squaring your way there is O(log n), the same halving idea as binary search."
+---
+
+## The problem
+
+Implement `pow(x, n)`: compute `x` raised to the integer power `n`. The exponent can be **negative**.
+
+**Examples:** `pow(2, 10) = 1024`, `pow(2, -2) = 0.25`.
+
+## Approach 1 — Multiply in a loop
+
+```js
+function myPow(x, n) {
+  const e = Math.abs(n)
+  let result = 1
+  for (let i = 0; i < e; i++) result *= x
+  return n < 0 ? 1 / result : result
+}
+```
+
+**Time:** O(|n|). With n up to ±2³¹, that's two billion multiplications — and on LeetCode this times out. The waste: computing `x⁶⁴` this way ignores that we passed `x³²` along the way, which is just one squaring from the answer.
+
+## Approach 2 — Binary exponentiation (recursive)
+
+Halve the exponent instead of decrementing it:
+
+- `x²ᵏ = (xᵏ)²` — one recursive call plus one squaring
+- `x²ᵏ⁺¹ = x · (xᵏ)²` — same, times one extra `x`
+
+```js
+function myPow(x, n) {
+  if (n < 0) return 1 / myPow(x, -n)
+
+  function fastPow(base, e) {
+    if (e === 0) return 1
+    const half = fastPow(base, Math.floor(e / 2))
+    return e % 2 === 0 ? half * half : half * half * base
+  }
+  return fastPow(x, n)
+}
+```
+
+**Time:** O(log n) — the exponent halves every call. **Space:** O(log n) stack.
+
+The crucial detail: compute `half` **once** and square it. Writing `fastPow(e/2) * fastPow(e/2)` recurses twice and collapses right back to O(n).
+
+## Approach 3 — Iterative (binary digits of the exponent)
+
+Read the exponent's bits from least significant to most: keep squaring `base`, and multiply it into the result whenever the current bit is 1. This is the version used everywhere in practice (modular arithmetic, crypto, matrix powers).
+
+```js
+function myPow(x, n) {
+  let e = Math.abs(n)
+  let base = x
+  let result = 1
+
+  while (e > 0) {
+    if (e % 2 === 1) result *= base
+    base *= base
+    e = Math.floor(e / 2)
+  }
+  return n < 0 ? 1 / result : result
+}
+```
+
+Same O(log n), O(1) space.
+
+## Dry run
+
+Approach 3 with `x = 2`, `n = 10` (binary `1010`):
+
+<Table
+  data={{
+    headers: ['e', 'Bit odd?', 'result', 'base (squares each step)'],
+    rows: [
+      ['10', 'no', '1', '2 → 4'],
+      ['5', 'yes', '1 × 4 = 4', '4 → 16'],
+      ['2', 'no', '4', '16 → 256'],
+      ['1', 'yes', '4 × 256 = 1024', '256 → 65536'],
+      ['0', '—', '1024 — done', ''],
+    ],
+  }}
+/>
+
+Four loop iterations instead of ten multiplications; for n = 10⁹ it's thirty instead of a billion.
+
+## Edge cases
+
+- `n = 0` → 1, for any x (even 0 by this problem's convention).
+- Negative exponent → invert once at the end (or up front); done per-step it compounds floating-point error.
+- In fixed-width languages, negating `INT_MIN` overflows — the classic fix is computing with the exponent as a wider/positive type. JavaScript's numbers dodge this, but say it out loud in interviews.
+- `x = 0` with negative n is division by zero — mention it, LeetCode promises it away.

--- a/src/app/dsa/patterns/questions/subsets.mdx
+++ b/src/app/dsa/patterns/questions/subsets.mdx
@@ -1,0 +1,94 @@
+---
+title: "Subsets"
+pattern: "backtracking"
+order: 1001
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/subsets/"
+gfg: "https://www.geeksforgeeks.org/dsa/power-set/"
+summary: "The hello-world of backtracking: at each element, branch on include vs. exclude — and learn why you push, recurse, then pop."
+---
+
+## The problem
+
+Given an array of **unique** integers, return every possible subset (the power set), in any order.
+
+**Example:** `nums = [1, 2, 3]` → `[[], [1], [2], [3], [1, 2], [1, 3], [2, 3], [1, 2, 3]]` — 2³ = 8 subsets.
+
+Each element is either *in* or *out* of a subset, independently. That's 2ⁿ combinations, and the job is to enumerate them without duplicates or misses.
+
+## Approach 1 — Backtracking (include / exclude as you go)
+
+Build one subset in a shared `path` array. At position `start`, loop over each candidate element, and for each: **choose** it (push), **explore** (recurse with the next start), **unchoose** (pop). Recording `path` at every node of the recursion — not just the leaves — captures all subsets.
+
+```js
+function subsets(nums) {
+  const result = []
+  const path = []
+
+  function backtrack(start) {
+    result.push([...path]) // snapshot — path keeps mutating!
+
+    for (let i = start; i < nums.length; i++) {
+      path.push(nums[i])   // choose
+      backtrack(i + 1)     // explore everything that starts this way
+      path.pop()           // unchoose — restore state for the next branch
+    }
+  }
+
+  backtrack(0)
+  return result
+}
+```
+
+**Time:** O(n · 2ⁿ) — 2ⁿ subsets, each copied in up to O(n). **Space:** O(n) recursion depth (beyond the output).
+
+Two lines carry all the meaning:
+
+- `result.push([...path])` — the **copy** is mandatory; pushing `path` itself would fill the result with references to one repeatedly-emptied array.
+- `path.pop()` — the **backtrack**. Without it, choices leak from one branch into its siblings.
+
+## Approach 2 — Iterative doubling
+
+Start with `[[]]`. For each number, extend every existing subset with it, keeping both versions.
+
+```js
+function subsets(nums) {
+  let result = [[]]
+  for (const num of nums) {
+    result = result.concat(result.map((set) => [...set, num]))
+  }
+  return result
+}
+```
+
+Same O(n · 2ⁿ). Elegant — and worth pairing with the observation that subset k corresponds to the **bitmask** of k: bit i set means take `nums[i]` (a third approach, useful when n ≤ 20).
+
+## Dry run
+
+Backtracking on `[1, 2, 3]`. Each row is a call or an action inside one:
+
+<Table
+  data={{
+    headers: ['Action', 'path', 'Recorded so far'],
+    rows: [
+      ['enter backtrack(0), record []', '[]', '8 total: []'],
+      ['choose 1, enter backtrack(1), record', '[1]', '…, [1]'],
+      ['choose 2, enter backtrack(2), record', '[1, 2]', '…, [1, 2]'],
+      ['choose 3, enter backtrack(3), record', '[1, 2, 3]', '…, [1, 2, 3]'],
+      ['pop 3, pop 2 — back in backtrack(1)', '[1]', ''],
+      ['choose 3, enter backtrack(3), record', '[1, 3]', '…, [1, 3]'],
+      ['pop 3, pop 1 — back in backtrack(0)', '[]', ''],
+      ['choose 2, enter backtrack(2), record', '[2]', '…, [2]'],
+      ['choose 3, enter backtrack(3), record', '[2, 3]', '…, [2, 3]'],
+      ['pop 3, pop 2, choose 3, record', '[3]', '…, [3]'],
+    ],
+  }}
+/>
+
+The push → recurse → pop rhythm visits each of the 8 subsets exactly once, in depth-first order.
+
+## Edge cases
+
+- Empty input → `[[]]` — the empty set is always a subset.
+- If the input can contain **duplicates** (Subsets II, LC 90): sort first, then inside the loop skip `nums[i] === nums[i - 1]` when `i > start`. Same skeleton, one guard line.
+- Output size is exponential by nature — no algorithm does better than O(2ⁿ) here, so don't chase it.

--- a/src/app/dsa/patterns/questions/three-sum.mdx
+++ b/src/app/dsa/patterns/questions/three-sum.mdx
@@ -1,0 +1,113 @@
+---
+title: "3Sum"
+pattern: "two-pointers"
+order: 102
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/3sum/"
+gfg: "https://www.geeksforgeeks.org/dsa/find-a-triplet-that-sum-to-a-given-value/"
+summary: "Fix one number, then run Two Sum II on the rest — plus the duplicate-skipping trick that trips everyone up the first time."
+---
+
+## The problem
+
+Given an integer array, return **all unique triplets** `[a, b, c]` such that `a + b + c = 0`. The same triplet must not appear twice in the output.
+
+**Example:** `nums = [-1, 0, 1, 2, -1, -4]`
+
+The answer is `[[-1, -1, 2], [-1, 0, 1]]`. Note that `[-1, 0, 1]` appears only once even though there are two `-1`s in the input.
+
+Two things make this harder than Two Sum: there are three numbers, and duplicates in the input can produce duplicate triplets in the output.
+
+## Approach 1 — Brute force
+
+Three nested loops, and a set to deduplicate sorted triplets.
+
+```js
+function threeSum(nums) {
+  const seen = new Set()
+  const result = []
+  for (let i = 0; i < nums.length; i++) {
+    for (let j = i + 1; j < nums.length; j++) {
+      for (let k = j + 1; k < nums.length; k++) {
+        if (nums[i] + nums[j] + nums[k] === 0) {
+          const triplet = [nums[i], nums[j], nums[k]].sort((a, b) => a - b)
+          const key = triplet.join(',')
+          if (!seen.has(key)) {
+            seen.add(key)
+            result.push(triplet)
+          }
+        }
+      }
+    }
+  }
+  return result
+}
+```
+
+**Time:** O(n³). **Space:** O(n) for deduplication. Too slow for n in the thousands.
+
+## Approach 2 — Sort + two pointers
+
+Sort the array. Then for each index `i`, the problem becomes: *find two numbers to the right of `i` that sum to `-nums[i]`* — which is exactly Two Sum II.
+
+Sorting also solves deduplication: equal values sit next to each other, so we skip a value if it equals the one we just processed.
+
+```js
+function threeSum(nums) {
+  nums.sort((a, b) => a - b)
+  const result = []
+
+  for (let i = 0; i < nums.length - 2; i++) {
+    if (nums[i] > 0) break                      // rest are positive, no zero sum possible
+    if (i > 0 && nums[i] === nums[i - 1]) continue // skip duplicate anchors
+
+    let left = i + 1
+    let right = nums.length - 1
+    while (left < right) {
+      const sum = nums[i] + nums[left] + nums[right]
+      if (sum < 0) {
+        left++
+      } else if (sum > 0) {
+        right--
+      } else {
+        result.push([nums[i], nums[left], nums[right]])
+        while (left < right && nums[left] === nums[left + 1]) left++
+        while (left < right && nums[right] === nums[right - 1]) right--
+        left++
+        right--
+      }
+    }
+  }
+  return result
+}
+```
+
+**Time:** O(n²) — n anchors × linear two-pointer scan (sorting's O(n log n) is dominated). **Space:** O(1) beyond the output.
+
+## Dry run
+
+After sorting: `nums = [-4, -1, -1, 0, 1, 2]`.
+
+<Table
+  data={{
+    headers: ['Anchor i', 'left', 'right', 'Sum', 'Action'],
+    rows: [
+      ['0 (-4)', '1 (-1)', '5 (2)', '-3', 'Too small — left++'],
+      ['0 (-4)', '2 (-1)', '5 (2)', '-3', 'Too small — left++'],
+      ['0 (-4)', '3 (0)', '5 (2)', '-2', 'Too small — left++'],
+      ['0 (-4)', '4 (1)', '5 (2)', '-1', 'Too small — left++, window closes'],
+      ['1 (-1)', '2 (-1)', '5 (2)', '0', 'Found [-1, -1, 2] — move both in'],
+      ['1 (-1)', '3 (0)', '4 (1)', '0', 'Found [-1, 0, 1] — move both in, window closes'],
+      ['2 (-1)', '—', '—', '—', 'Same as previous anchor — skipped'],
+      ['3 (0)', '4 (1)', '5 (2)', '3', 'Too big — right--, window closes'],
+    ],
+  }}
+/>
+
+The duplicate `-1` at index 2 is skipped as an anchor — that's what keeps `[-1, 0, 1]` from appearing twice.
+
+## Edge cases
+
+- Fewer than 3 elements → return `[]`.
+- All zeros `[0, 0, 0, 0]` → exactly one triplet `[0, 0, 0]`; the inner duplicate-skips handle it.
+- The `nums[i] > 0` early exit matters: once the anchor is positive, three positives can never sum to zero.

--- a/src/app/dsa/patterns/questions/top-k-frequent-elements.mdx
+++ b/src/app/dsa/patterns/questions/top-k-frequent-elements.mdx
@@ -1,0 +1,104 @@
+---
+title: "Top K Frequent Elements"
+pattern: "heap-top-k"
+order: 702
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/top-k-frequent-elements/"
+gfg: "https://www.geeksforgeeks.org/dsa/find-k-numbers-occurrences-given-array/"
+summary: "Count with a map, then pick the top k — by sorting, by heap, or in O(n) with the bucket trick."
+---
+
+## The problem
+
+Given an integer array and `k`, return the `k` most frequent elements (any order; the answer is guaranteed unique).
+
+**Example:** `nums = [1, 1, 1, 2, 2, 3]`, `k = 2` → answer `[1, 2]` (1 appears 3 times, 2 appears twice, 3 once).
+
+Every approach starts the same way — count frequencies with a hash map. The approaches differ in how they extract the top k from those counts.
+
+```js
+function countFrequencies(nums) {
+  const freq = new Map()
+  for (const num of nums) {
+    freq.set(num, (freq.get(num) ?? 0) + 1)
+  }
+  return freq
+}
+```
+
+## Approach 1 — Count, then sort by frequency
+
+```js
+function topKFrequent(nums, k) {
+  const freq = countFrequencies(nums)
+  return [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, k)
+    .map(([num]) => num)
+}
+```
+
+**Time:** O(u log u) where u = number of distinct values. **Space:** O(u). Simple and usually what you'd write in production — but sorting *all* distinct values is more than the question asks for.
+
+## Approach 2 — Min-heap of size k
+
+Same trick as Kth Largest: stream over the `(value, count)` pairs keeping a min-heap (ordered by count) of size k. Each pair costs O(log k) instead of O(log u).
+
+**Time:** O(u log k). Worth it when k is much smaller than the number of distinct values, or when counts arrive as a stream.
+
+## Approach 3 — Bucket sort by count (O(n))
+
+A frequency can only be `1` to `n`. So make `n + 1` buckets, where `buckets[c]` holds every value that occurs exactly `c` times — then read buckets from the high end until you've collected k values. No comparisons, no log factor.
+
+```js
+function topKFrequent(nums, k) {
+  const freq = countFrequencies(nums)
+
+  const buckets = Array.from({ length: nums.length + 1 }, () => [])
+  for (const [num, count] of freq) {
+    buckets[count].push(num)
+  }
+
+  const result = []
+  for (let count = buckets.length - 1; count >= 0 && result.length < k; count--) {
+    result.push(...buckets[count])
+  }
+  return result.slice(0, k)
+}
+```
+
+**Time:** O(n). **Space:** O(n). The rare case where you beat the heap — because the "keys" (counts) live in a small known range.
+
+## Dry run
+
+Approach 3 on `nums = [1, 1, 1, 2, 2, 3]`, `k = 2`:
+
+**Step 1 — count:** `1 → 3`, `2 → 2`, `3 → 1`.
+
+**Step 2 — bucket by count** (n = 6, so 7 buckets):
+
+<Table
+  data={{
+    headers: ['Bucket (count)', '0', '1', '2', '3', '4', '5', '6'],
+    rows: [['Values', '—', '3', '2', '1', '—', '—', '—']],
+  }}
+/>
+
+**Step 3 — collect from the top:**
+
+<Table
+  data={{
+    headers: ['Reading bucket', 'Found', 'Result', 'Have k = 2?'],
+    rows: [
+      ['6, 5, 4', 'nothing', '[]', 'no'],
+      ['3', '1', '[1]', 'no'],
+      ['2', '2', '[1, 2]', 'yes — stop'],
+    ],
+  }}
+/>
+
+## Edge cases
+
+- `k` equals the number of distinct values → return everything.
+- One bucket can hold several values (ties): `[1, 1, 2, 2]`, k = 1 — either answer is accepted by the problem, and the final `slice(0, k)` keeps the size right.
+- All elements identical → one non-empty bucket at index n.

--- a/src/app/dsa/patterns/questions/two-sum-ii.mdx
+++ b/src/app/dsa/patterns/questions/two-sum-ii.mdx
@@ -1,0 +1,92 @@
+---
+title: "Two Sum II — Input Array Is Sorted"
+pattern: "two-pointers"
+order: 101
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/two-sum-ii-input-array-is-sorted/"
+gfg: "https://www.geeksforgeeks.org/dsa/two-pointers-technique/"
+summary: "The cleanest introduction to two pointers — use the sorted order to walk in from both ends instead of checking every pair."
+---
+
+## The problem
+
+You're given a **sorted** array of numbers and a target. Return the 1-indexed positions of the two numbers that add up to the target. Exactly one solution exists, and you can't use the same element twice.
+
+**Example:** `numbers = [1, 3, 4, 6, 8, 11]`, `target = 10`
+
+The answer is `[3, 4]` because `numbers[3] = 4` and `numbers[4] = 6` (1-indexed) add up to `10`.
+
+The word to notice is *sorted*. The plain Two Sum problem needs a hash map, but sorted order gives us something better: from any pair, we know which direction to move to make the sum bigger or smaller.
+
+## Approach 1 — Brute force
+
+Check every pair. For each element, scan everything after it.
+
+```js
+function twoSum(numbers, target) {
+  for (let i = 0; i < numbers.length; i++) {
+    for (let j = i + 1; j < numbers.length; j++) {
+      if (numbers[i] + numbers[j] === target) {
+        return [i + 1, j + 1]
+      }
+    }
+  }
+  return []
+}
+```
+
+**Time:** O(n²) — every pair. **Space:** O(1).
+
+This works but completely ignores the fact that the array is sorted.
+
+## Approach 2 — Two pointers
+
+Put one pointer at each end and look at the sum:
+
+- Sum **too big** → we need a smaller number → move `right` inward.
+- Sum **too small** → we need a bigger number → move `left` inward.
+- Sum **equals target** → done.
+
+Each step safely throws away one element, because sorted order guarantees no valid pair can use it.
+
+```js
+function twoSum(numbers, target) {
+  let left = 0
+  let right = numbers.length - 1
+
+  while (left < right) {
+    const sum = numbers[left] + numbers[right]
+    if (sum === target) return [left + 1, right + 1]
+    if (sum < target) left++
+    else right--
+  }
+  return []
+}
+```
+
+**Time:** O(n) — the pointers only ever move toward each other. **Space:** O(1).
+
+## Dry run
+
+`numbers = [1, 3, 4, 6, 8, 11]`, `target = 10`:
+
+<Table
+  data={{
+    headers: ['Step', 'left', 'right', 'Sum', 'Decision'],
+    rows: [
+      ['1', '0 (1)', '5 (11)', '12', 'Too big — move right in'],
+      ['2', '0 (1)', '4 (8)', '9', 'Too small — move left in'],
+      ['3', '1 (3)', '4 (8)', '11', 'Too big — move right in'],
+      ['4', '1 (3)', '3 (6)', '9', 'Too small — move left in'],
+      ['5', '2 (4)', '3 (6)', '10', 'Found — return [3, 4]'],
+    ],
+  }}
+/>
+
+Five comparisons instead of up to fifteen pairs — and the gap grows fast with input size.
+
+## Edge cases
+
+- Negative numbers work unchanged — sorted order is all that matters.
+- Duplicates are fine: if `[3, 3]` sums to the target, `left` and `right` land on the two copies.
+- The `left < right` condition prevents using the same element twice.

--- a/src/app/dsa/patterns/questions/valid-parentheses.mdx
+++ b/src/app/dsa/patterns/questions/valid-parentheses.mdx
@@ -1,0 +1,103 @@
+---
+title: "Valid Parentheses"
+pattern: "stack"
+order: 601
+difficulty: "Easy"
+leetcode: "https://leetcode.com/problems/valid-parentheses/"
+gfg: "https://www.geeksforgeeks.org/dsa/check-for-balanced-parentheses-in-an-expression/"
+summary: "The purest stack problem: every closer must match the most recently opened bracket — last in, first out."
+---
+
+## The problem
+
+Given a string containing only `()[]{}`, decide whether it's valid: every opener is closed by the same type of bracket, and brackets close in the correct order.
+
+**Examples:**
+
+- `"()[]{}"` → `true`
+- `"([{}])"` → `true` — nesting is fine
+- `"(]"` → `false` — wrong type
+- `"([)]"` → `false` — right types, wrong **order**: the `(` must wait until `[` closes
+
+The order requirement is the key. When we hit a closing bracket, the opener it must match is the **most recent unclosed one** — "most recent first" is exactly what a stack gives you.
+
+## Approach 1 — Repeatedly delete matched pairs
+
+Any valid string must contain an innermost pair like `()`, `[]`, or `{}` sitting adjacent. Delete matched pairs until nothing changes; valid strings shrink to empty.
+
+```js
+function isValid(s) {
+  let prev = null
+  while (prev !== s) {
+    prev = s
+    s = s.replaceAll('()', '').replaceAll('[]', '').replaceAll('{}', '')
+  }
+  return s.length === 0
+}
+```
+
+**Time:** O(n²) — each pass scans the string and removes as little as one pair. A neat mental model, not a real solution.
+
+## Approach 2 — Stack
+
+Push every opener. For a closer, the top of the stack must be its partner — pop it. Anything else (wrong partner, or an empty stack) means invalid. At the end, the stack must be empty.
+
+```js
+function isValid(s) {
+  const stack = []
+  const pairs = { ')': '(', ']': '[', '}': '{' }
+
+  for (const ch of s) {
+    if (ch === '(' || ch === '[' || ch === '{') {
+      stack.push(ch)
+    } else {
+      if (stack.pop() !== pairs[ch]) return false
+    }
+  }
+  return stack.length === 0
+}
+```
+
+**Time:** O(n) — one push or pop per character. **Space:** O(n) worst case (all openers, e.g. `"((((("`).
+
+Note `stack.pop()` on an empty array returns `undefined`, which never equals an opener — so the "closer with nothing open" case falls out of the same comparison for free.
+
+## Dry run
+
+`s = "([)]"` — the tricky wrong-order case:
+
+<Table
+  data={{
+    headers: ['Char', 'Action', 'Stack after'],
+    rows: [
+      ['(', 'opener — push', '('],
+      ['[', 'opener — push', '( ['],
+      [')', 'closer — pop [ but need (', 'mismatch → false'],
+    ],
+  }}
+/>
+
+And `s = "([{}])"` — valid nesting:
+
+<Table
+  data={{
+    headers: ['Char', 'Action', 'Stack after'],
+    rows: [
+      ['(', 'push', '('],
+      ['[', 'push', '( ['],
+      ['{', 'push', '( [ {'],
+      ['}', 'pop { — match', '( ['],
+      [']', 'pop [ — match', '('],
+      [')', 'pop ( — match', '(empty)'],
+    ],
+  }}
+/>
+
+Stack empty at the end → `true`.
+
+## Edge cases
+
+- Empty string → valid (nothing to match).
+- Odd length → always invalid; you can return `false` immediately as a micro-optimization.
+- Leftover openers like `"(("` → matched nothing wrong, but the final `stack.length === 0` check catches them.
+- `"]"` alone → pop on empty stack → `undefined !== '['` → false, no special-casing needed.

--- a/src/app/dsa/patterns/questions/validate-bst.mdx
+++ b/src/app/dsa/patterns/questions/validate-bst.mdx
@@ -1,0 +1,103 @@
+---
+title: "Validate Binary Search Tree"
+pattern: "tree-bfs-dfs"
+order: 802
+difficulty: "Medium"
+leetcode: "https://leetcode.com/problems/validate-binary-search-tree/"
+gfg: "https://www.geeksforgeeks.org/dsa/a-program-to-check-if-a-binary-tree-is-bst-or-not/"
+summary: "The classic trap: checking each node against its children isn't enough — you must carry min/max bounds down the tree."
+---
+
+## The problem
+
+Given the root of a binary tree, determine whether it's a valid **binary search tree**: every node's left subtree contains only values *less than* the node, the right subtree only values *greater*, and both subtrees are themselves BSTs.
+
+**Example of the trap:** this tree is **not** a valid BST, even though every parent-child pair looks fine locally:
+
+```
+      5
+     / \
+    1   6
+       / \
+      3   8
+```
+
+`6 > 5` ✓ and `3 < 6` ✓ — but `3` sits in the **right subtree of 5**, and `3 < 5`. The BST property is about entire subtrees, not just direct children.
+
+## Approach 1 — Check children only (the wrong answer)
+
+```js
+// WRONG — accepts the tree above
+function isValidBST(root) {
+  if (!root) return true
+  if (root.left && root.left.val >= root.val) return false
+  if (root.right && root.right.val <= root.val) return false
+  return isValidBST(root.left) && isValidBST(root.right)
+}
+```
+
+Worth writing out because interviewers *expect* you to know why it fails: the check never learns that everything under `5.right` must also stay above 5.
+
+## Approach 2 — DFS with min/max bounds
+
+Pass down the open interval each node must lie in. The root can be anything; going left tightens the upper bound, going right tightens the lower bound.
+
+```js
+function isValidBST(root) {
+  function valid(node, low, high) {
+    if (!node) return true
+    if (node.val <= low || node.val >= high) return false
+    return (
+      valid(node.left, low, node.val) &&
+      valid(node.right, node.val, high)
+    )
+  }
+  return valid(root, -Infinity, Infinity)
+}
+```
+
+**Time:** O(n) — each node checked once. **Space:** O(h) recursion depth.
+
+## Approach 3 — In-order traversal must be sorted
+
+In-order traversal of a BST (left, node, right) visits values in strictly increasing order. So traverse in-order and verify each value exceeds the previous one.
+
+```js
+function isValidBST(root) {
+  let prev = -Infinity
+  function inorder(node) {
+    if (!node) return true
+    if (!inorder(node.left)) return false
+    if (node.val <= prev) return false
+    prev = node.val
+    return inorder(node.right)
+  }
+  return inorder(root)
+}
+```
+
+Same O(n) / O(h), and a nice reminder that "in-order of a BST is sorted" is a reusable fact (it's also how you solve Kth Smallest in a BST).
+
+## Dry run
+
+Approach 2 on the trap tree (`5`, left `1`, right `6` with children `3` and `8`):
+
+<Table
+  data={{
+    headers: ['Node', 'Allowed range', 'In range?', 'Result'],
+    rows: [
+      ['5', '(-∞, ∞)', 'yes', 'recurse'],
+      ['1', '(-∞, 5)', 'yes', 'leaf — true'],
+      ['6', '(5, ∞)', 'yes', 'recurse'],
+      ['3', '(5, 6)', '3 <= 5 — NO', 'false bubbles up'],
+    ],
+  }}
+/>
+
+The bound `(5, 6)` is the information Approach 1 never had: `3` must be greater than its grandparent `5`, not just less than its parent `6`.
+
+## Edge cases
+
+- Empty tree and single node → valid.
+- **Duplicates are invalid** under this problem's definition — hence `<=` / `>=` in the bound checks, not `<` / `>`.
+- Node values at integer extremes: using `-Infinity`/`Infinity` (or `null` sentinels) avoids the classic bug where `Number.MIN_SAFE_INTEGER` bounds reject legitimate extreme values.

--- a/src/app/dsa/patterns/utils.ts
+++ b/src/app/dsa/patterns/utils.ts
@@ -1,0 +1,67 @@
+import fs from 'fs'
+import path from 'path'
+
+export type QuestionDifficulty = 'Easy' | 'Medium' | 'Hard'
+
+export type QuestionMetadata = {
+  title: string
+  pattern: string
+  order: number
+  difficulty: QuestionDifficulty
+  summary: string
+  leetcode?: string
+  gfg?: string
+}
+
+export type PatternQuestion = {
+  metadata: QuestionMetadata
+  slug: string
+  content: string
+}
+
+function parseFrontmatter(fileContent: string) {
+  const frontmatterRegex = /---\s*([\s\S]*?)\s*---/
+  const match = frontmatterRegex.exec(fileContent)
+  const frontMatterBlock = match![1]
+  const content = fileContent.replace(frontmatterRegex, '').trim()
+  const frontMatterLines = frontMatterBlock.trim().split('\n')
+  const metadata: Record<string, string> = {}
+
+  frontMatterLines.forEach((line) => {
+    const [key, ...valueArr] = line.split(': ')
+    let value = valueArr.join(': ').trim()
+    value = value.replace(/^['"](.*)['"]$/, '$1') // Remove quotes
+    metadata[key.trim()] = value
+  })
+
+  return {
+    metadata: {
+      title: metadata.title,
+      pattern: metadata.pattern,
+      order: Number(metadata.order ?? 0),
+      difficulty: metadata.difficulty as QuestionDifficulty,
+      summary: metadata.summary,
+      leetcode: metadata.leetcode,
+      gfg: metadata.gfg,
+    } satisfies QuestionMetadata,
+    content,
+  }
+}
+
+export function getPatternQuestions(): PatternQuestion[] {
+  const dir = path.join(process.cwd(), 'src', 'app', 'dsa', 'patterns', 'questions')
+  return fs
+    .readdirSync(dir)
+    .filter((file) => path.extname(file) === '.mdx')
+    .map((file) => {
+      const { metadata, content } = parseFrontmatter(
+        fs.readFileSync(path.join(dir, file), 'utf-8')
+      )
+      return {
+        metadata,
+        slug: path.basename(file, path.extname(file)),
+        content,
+      }
+    })
+    .sort((a, b) => a.metadata.order - b.metadata.order)
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { getBlogPosts } from '@/app/blog/utils'
+import { getPatternQuestions } from '@/app/dsa/patterns/utils'
 
 export const baseUrl = 'https://adarshm.com'
 
@@ -10,12 +11,19 @@ export default async function sitemap() {
     priority: 0.8,
   }))
 
-  let routes = ['', '/blog', '/dsa'].map((route) => ({
+  let questions = getPatternQuestions().map((question) => ({
+    url: `${baseUrl}/dsa/patterns/${question.slug}`,
+    lastModified: new Date().toISOString().split('T')[0],
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }))
+
+  let routes = ['', '/blog', '/dsa', '/dsa/patterns'].map((route) => ({
     url: `${baseUrl}${route}`,
     lastModified: new Date().toISOString().split('T')[0],
     changeFrequency: 'weekly' as const,
     priority: route === '' ? 1 : 0.9,
   }))
 
-  return [...routes, ...blogs]
+  return [...routes, ...blogs, ...questions]
 }


### PR DESCRIPTION
## Summary

Adds a pattern-wise DSA practice section at **`/dsa/patterns`**: 26 fully worked questions grouped under 12 patterns (Two Pointers, Sliding Window, Fast & Slow Pointers, Merge Intervals, Binary Search, Stack/Monotonic Stack, Heap/Top-K, Tree BFS/DFS, Graphs, Backtracking, Dynamic Programming, and Math & Number Theory).

- **Index page** — each pattern has a description, a "how to spot it" hint, question rows with difficulty badges and direct LeetCode/GFG links, plus 3–4 extra practice links. Includes an "X of 26 solved" progress tracker persisted in localStorage, styled like the existing Learn DSA path.
- **Question detail pages** (statically generated) — each question is explained with a concrete example, multiple approaches (brute force → optimal, with code, complexity, and why the naive approach fails), a step-by-step dry-run table, and edge cases. A "Mark as solved" button shares progress state with the index, and prev/next links navigate within a pattern.
- **Content pipeline** — questions live as MDX files with frontmatter in `src/app/dsa/patterns/questions/`, mirroring the blog's content pipeline; adding a question is just a new `.mdx` file.
- **Integration** — cross-link card on `/dsa`, and all new URLs added to the sitemap.

## Notable fix

next-mdx-remote v6 strips JSX expression props by default (`blockJS: true`), which silently removed the `data` prop from the `<Table>` dry-run tables. The question detail page passes `blockJS: false` for this trusted, repo-authored content (`blockDangerousJS` remains on). Blog rendering is unchanged.

## Testing

- `yarn build` passes — all 81 pages generate, including the 26 new question pages.
- Verified rendering in light and dark mode via headless Chromium screenshots (index, detail pages, dry-run tables, `/dsa` cross-link).
- Note: `yarn lint` fails on `master` too — Next.js 16 removed `next lint`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5QKkoEWdUfJyh7F5k9qHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5QKkoEWdUfJyh7F5k9qHy)_